### PR TITLE
#62 set correct object key during exposed service creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- [#64] Fix the creation of service annotations by ignoring all irrelevant environment variables and by correctly 
+  splitting environment variables containing multiple `=`.  
 
 ## [v0.16.0] - 2022-11-18
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
-- [#64] Fix the creation of service annotations by ignoring all irrelevant environment variables and by correctly 
-  splitting environment variables containing multiple `=`.  
+- [#62] Fix wrong exposed service object key. During the creation of exposed services some wrong object keys are used. 
+  Later-on this leads to an error when tried to get these resources.
+- [#64] Fix the creation of service annotations by ignoring all irrelevant environment variables and by correctly
+  splitting environment variables containing multiple `=`.
 
 ## [v0.16.0] - 2022-11-18
 ### Added

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,14 +1,14 @@
 resources:
-  - manager.yaml
+- manager.yaml
 generatorOptions:
   disableNameSuffixHash: true
 configMapGenerator:
-  - files:
-      - controller_manager_config.yaml
-    name: manager-config
+- files:
+  - controller_manager_config.yaml
+  name: manager-config
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
-  - name: controller
-    newName: cloudogu/k8s-dogu-operator
-    newTag: 0.16.0
+- name: controller
+  newName: cloudogu/k8s-dogu-operator
+  newTag: 0.16.0

--- a/controllers/annotation/ces_service_annotator.go
+++ b/controllers/annotation/ces_service_annotator.go
@@ -106,12 +106,12 @@ func getServiceVariablesFromEnvVariables(envVariables []string) (map[string]stri
 	serviceVariables := map[string]string{}
 
 	for _, envVariables := range envVariables {
-		name, value, err := splitEnvVariable(envVariables)
-		if err != nil {
-			return map[string]string{}, fmt.Errorf("failed to split environment variable: %w", err)
-		}
+		if strings.HasPrefix(envVariables, serviceVarsPrefix) {
+			name, value, err := splitEnvVariable(envVariables)
+			if err != nil {
+				return map[string]string{}, fmt.Errorf("failed to split environment variable: %w", err)
+			}
 
-		if strings.HasPrefix(name, serviceVarsPrefix) {
 			trimmedVariable := strings.TrimPrefix(name, serviceVarsPrefix)
 			serviceVariables[trimmedVariable] = value
 		}
@@ -121,7 +121,7 @@ func getServiceVariablesFromEnvVariables(envVariables []string) (map[string]stri
 }
 
 func splitEnvVariable(variable string) (string, string, error) {
-	variableParts := strings.Split(variable, "=")
+	variableParts := strings.SplitN(variable, "=", 2)
 
 	if len(variableParts) != 2 {
 		return "", "", fmt.Errorf("environment variable [%s] needs to be in form NAME=VALUE", variable)

--- a/controllers/annotation/testdata/test_non_service_env_vars.json
+++ b/controllers/annotation/testdata/test_non_service_env_vars.json
@@ -1,0 +1,10 @@
+{
+  "Env": [
+    "SERVICE_80_TAGS=webapp",
+    "TEST=WDW=WDWD=webapp",
+    "SERVICE_80_TAGS=webapp=true"
+  ],
+  "ExposedPorts": {
+    "80/tcp": {}
+  }
+}

--- a/controllers/annotation/testdata/test_non_service_env_vars.yaml
+++ b/controllers/annotation/testdata/test_non_service_env_vars.yaml
@@ -1,0 +1,13 @@
+# This yaml contains a ces service annotation for the web app. Only the annotations are compared.
+apiVersion: v1
+kind: Service
+metadata:
+  name: serviceName
+  annotations:
+    k8s-dogu-operator.cloudogu.com/ces-services: '[{"name":"serviceName","port":80,"location":"/serviceName","pass":"/serviceName"}]'
+spec:
+  selector:
+    name: serviceName
+  ports:
+    - protocol: TCP
+      port: 80

--- a/controllers/resource/upserter_test.go
+++ b/controllers/resource/upserter_test.go
@@ -2,8 +2,9 @@ package resource
 
 import (
 	"context"
-	"github.com/cloudogu/k8s-dogu-operator/internal/mocks/external"
 	"testing"
+
+	"github.com/cloudogu/k8s-dogu-operator/internal/mocks/external"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
@@ -324,7 +325,7 @@ func Test_upserter_UpsertDoguExposedServices(t *testing.T) {
 
 		client := external.NewClient(t)
 		failedToCreateFirstError := errors.New("failed on exposed service 1")
-		client.On("Get", context.Background(), doguResource.GetObjectKey(), &v1.Service{}).Once().Return(failedToCreateFirstError)
+		client.On("Get", context.Background(), "ldap-exposed-2222", &v1.Service{}).Once().Return(failedToCreateFirstError)
 		failedToCreateSecondError := errors.New("failed on exposed service 2")
 		client.On("Get", context.Background(), doguResource.GetObjectKey(), &v1.Service{}).Once().Return(failedToCreateSecondError)
 

--- a/controllers/resource/upserter_test.go
+++ b/controllers/resource/upserter_test.go
@@ -15,6 +15,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -325,9 +326,9 @@ func Test_upserter_UpsertDoguExposedServices(t *testing.T) {
 
 		client := external.NewClient(t)
 		failedToCreateFirstError := errors.New("failed on exposed service 1")
-		client.On("Get", context.Background(), "ldap-exposed-2222", &v1.Service{}).Once().Return(failedToCreateFirstError)
+		client.On("Get", context.Background(), types.NamespacedName{Namespace: "ecosystem", Name: "ldap-exposed-2222"}, &v1.Service{}).Once().Return(failedToCreateFirstError)
 		failedToCreateSecondError := errors.New("failed on exposed service 2")
-		client.On("Get", context.Background(), doguResource.GetObjectKey(), &v1.Service{}).Once().Return(failedToCreateSecondError)
+		client.On("Get", context.Background(), types.NamespacedName{Namespace: "ecosystem", Name: "ldap-exposed-8888"}, &v1.Service{}).Once().Return(failedToCreateSecondError)
 
 		generator := mocks.NewDoguResourceGenerator(t)
 		generator.On("CreateDoguExposedServices", doguResource, dogu).Return(readLdapDoguExpectedExposedServices(t), nil)

--- a/go.sum
+++ b/go.sum
@@ -166,18 +166,6 @@ github.com/cilium/ebpf v0.4.0/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJ
 github.com/cilium/ebpf v0.6.2/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
 github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6Dob7S7YxXgwXpfOuvO54S+tGdZdw9fuRZt25Ag=
 github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
-github.com/cloudogu/cesapp-lib v0.0.0-20221116082817-397fe54e3283 h1:a4g3KarXdk0C4+cuggnCvy48w3hpmwovuPp9O8SOWLs=
-github.com/cloudogu/cesapp-lib v0.0.0-20221116082817-397fe54e3283/go.mod h1:gASp3qQx1rBsHTUgi3G1Ac6dctu08cEhrLDPv6zs7Xo=
-github.com/cloudogu/cesapp-lib v0.0.0-20221116093932-533e1b519ea8 h1:4a1Mnz3rCeMFr/H9GWT67abbTlQT8tceMbXn1zgM0yM=
-github.com/cloudogu/cesapp-lib v0.0.0-20221116093932-533e1b519ea8/go.mod h1:gASp3qQx1rBsHTUgi3G1Ac6dctu08cEhrLDPv6zs7Xo=
-github.com/cloudogu/cesapp-lib v0.0.0-20221116133634-1e968e7d9161 h1:NdS5sTNoJMPASWNWNXQlkXsVap7doW6u42yP1UYVDoQ=
-github.com/cloudogu/cesapp-lib v0.0.0-20221116133634-1e968e7d9161/go.mod h1:PTQqI3xs1ReJMXYE6BGTF33yAfmS4J7P8UiE4AwDMDY=
-github.com/cloudogu/cesapp-lib v0.0.0-20221116152945-ea498c9bef1b h1:E8b4OQb3rZwNXWcsxYmZdSpkdGcu2e5VCVvZpA1Bk4s=
-github.com/cloudogu/cesapp-lib v0.0.0-20221116152945-ea498c9bef1b/go.mod h1:PTQqI3xs1ReJMXYE6BGTF33yAfmS4J7P8UiE4AwDMDY=
-github.com/cloudogu/cesapp-lib v0.0.0-20221117095903-2dc1d8e8c65c h1:gA30SN5ON4TEyGcTo5qPSO4z9J7sAj5kWKSmuZkg2Z4=
-github.com/cloudogu/cesapp-lib v0.0.0-20221117095903-2dc1d8e8c65c/go.mod h1:PTQqI3xs1ReJMXYE6BGTF33yAfmS4J7P8UiE4AwDMDY=
-github.com/cloudogu/cesapp-lib v0.8.0 h1:Vu/iG+mjk2QuEMHYWydYHDg973PytANYYU6IVrkzp38=
-github.com/cloudogu/cesapp-lib v0.8.0/go.mod h1:gASp3qQx1rBsHTUgi3G1Ac6dctu08cEhrLDPv6zs7Xo=
 github.com/cloudogu/cesapp-lib v0.9.0 h1:0yT7jpLKtu2X6qKG5s2UdgIojsQoyluidPRG2TwJASQ=
 github.com/cloudogu/cesapp-lib v0.9.0/go.mod h1:PTQqI3xs1ReJMXYE6BGTF33yAfmS4J7P8UiE4AwDMDY=
 github.com/cloudogu/k8s-apply-lib v0.4.0 h1:4jYj0gTDSvW0qs9d5yM5w8aOsMu5Sx+PBCwJwa5sMss=
@@ -874,7 +862,6 @@ github.com/stretchr/objx v0.0.0-20180129172003-8a3f7159479f/go.mod h1:HFkY916IF+
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
-github.com/stretchr/objx v0.4.0 h1:M2gUjqZET1qApGOWNSnZ49BAIMX4F/1plDv3+l31EJ4=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
@@ -886,7 +873,6 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=


### PR DESCRIPTION
The object key of the dogu resource was used as-is which is plain wrong. When the operator tries to get the exposed service resource the resource will not be returned because it is not found.

The resource generator creates quite specific object keys which includes the port. This commit changes to object to the correct generated key in order to find the exposed service later-on.