### PR TITLE
Add dogu client and cesappd-SA support

### DIFF
--- a/api/ecoSystem/doguClientSet.go
+++ b/api/ecoSystem/doguClientSet.go
@@ -1,0 +1,48 @@
+package ecoSystem
+
+import (
+	"github.com/cloudogu/k8s-dogu-operator/api/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+)
+
+type EcoSystemV1Alpha1Interface interface {
+	Dogus(namespace string) DoguInterface
+}
+
+type EcoSystemV1Alpha1Client struct {
+	restClient rest.Interface
+}
+
+func NewForConfig(c *rest.Config) (*EcoSystemV1Alpha1Client, error) {
+	config := *c
+	gv := schema.GroupVersion{Group: v1.GroupVersion.Group, Version: v1.GroupVersion.Version}
+	config.ContentConfig.GroupVersion = &gv
+	config.APIPath = "/apis"
+
+	s := scheme.Scheme
+	err := v1.AddToScheme(s)
+	if err != nil {
+		return nil, err
+	}
+
+	metav1.AddToGroupVersion(s, gv)
+	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	config.UserAgent = rest.DefaultKubernetesUserAgent()
+
+	client, err := rest.RESTClientFor(&config)
+	if err != nil {
+		return nil, err
+	}
+
+	return &EcoSystemV1Alpha1Client{restClient: client}, nil
+}
+
+func (c *EcoSystemV1Alpha1Client) Dogus(namespace string) DoguInterface {
+	return &doguClient{
+		client: c.restClient,
+		ns:     namespace,
+	}
+}

--- a/api/ecoSystem/doguClientSet_test.go
+++ b/api/ecoSystem/doguClientSet_test.go
@@ -1,0 +1,38 @@
+package ecoSystem
+
+import (
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
+	"testing"
+)
+
+func TestNewForConfig(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		// given
+		config := &rest.Config{}
+
+		// when
+		clientSet, err := NewForConfig(config)
+
+		// then
+		require.NoError(t, err)
+		require.NotNil(t, clientSet)
+	})
+
+}
+
+func TestEcoSystemV1Alpha1Client_Dogus(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		// given
+		config := &rest.Config{}
+		clientSet, err := NewForConfig(config)
+		require.NoError(t, err)
+		require.NotNil(t, clientSet)
+
+		// when
+		client := clientSet.Dogus("ecosystem")
+
+		// then
+		require.NotNil(t, client)
+	})
+}

--- a/api/ecoSystem/doguRestClient.go
+++ b/api/ecoSystem/doguRestClient.go
@@ -1,0 +1,159 @@
+package ecoSystem
+
+import (
+	"context"
+	"github.com/cloudogu/k8s-dogu-operator/api/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"time"
+)
+
+type DoguInterface interface {
+	Create(ctx context.Context, dogu *v1.Dogu, opts metav1.CreateOptions) (*v1.Dogu, error)
+	Update(ctx context.Context, dogu *v1.Dogu, opts metav1.UpdateOptions) (*v1.Dogu, error)
+	UpdateStatus(ctx context.Context, dogu *v1.Dogu, opts metav1.UpdateOptions) (*v1.Dogu, error)
+	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
+	Get(ctx context.Context, name string, opts metav1.GetOptions) (*v1.Dogu, error)
+	List(ctx context.Context, opts metav1.ListOptions) (*v1.DoguList, error)
+	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)
+	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1.Dogu, err error)
+}
+
+type doguClient struct {
+	client rest.Interface
+	ns     string
+}
+
+// Get takes name of the dogu, and returns the corresponding dogu object, and an error if there is any.
+func (d *doguClient) Get(ctx context.Context, name string, options metav1.GetOptions) (result *v1.Dogu, err error) {
+	result = &v1.Dogu{}
+	err = d.client.Get().
+		Namespace(d.ns).
+		Resource("dogus").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do(ctx).
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of Dogus that match those selectors.
+func (d *doguClient) List(ctx context.Context, opts metav1.ListOptions) (result *v1.DoguList, err error) {
+	var timeout time.Duration
+	if opts.TimeoutSeconds != nil {
+		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
+	}
+	result = &v1.DoguList{}
+	err = d.client.Get().
+		Namespace(d.ns).
+		Resource("dogus").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Timeout(timeout).
+		Do(ctx).
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested dogus.
+func (d *doguClient) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
+	var timeout time.Duration
+	if opts.TimeoutSeconds != nil {
+		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
+	}
+	opts.Watch = true
+	return d.client.Get().
+		Namespace(d.ns).
+		Resource("dogus").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Timeout(timeout).
+		Watch(ctx)
+}
+
+// Create takes the representation of a dogu and creates it.  Returns the server's representation of the dogu, and an error, if there is any.
+func (d *doguClient) Create(ctx context.Context, dogu *v1.Dogu, opts metav1.CreateOptions) (result *v1.Dogu, err error) {
+	result = &v1.Dogu{}
+	err = d.client.Post().
+		Namespace(d.ns).
+		Resource("dogus").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Body(dogu).
+		Do(ctx).
+		Into(result)
+	return
+}
+
+// Update takes the representation of a dogu and updates it. Returns the server's representation of the dogu, and an error, if there is any.
+func (d *doguClient) Update(ctx context.Context, dogu *v1.Dogu, opts metav1.UpdateOptions) (result *v1.Dogu, err error) {
+	result = &v1.Dogu{}
+	err = d.client.Put().
+		Namespace(d.ns).
+		Resource("dogus").
+		Name(dogu.Name).
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Body(dogu).
+		Do(ctx).
+		Into(result)
+	return
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+func (d *doguClient) UpdateStatus(ctx context.Context, dogu *v1.Dogu, opts metav1.UpdateOptions) (result *v1.Dogu, err error) {
+	result = &v1.Dogu{}
+	err = d.client.Put().
+		Namespace(d.ns).
+		Resource("dogus").
+		Name(dogu.Name).
+		SubResource("status").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Body(dogu).
+		Do(ctx).
+		Into(result)
+	return
+}
+
+// Delete takes name of the dogu and deletes it. Returns an error if one occurs.
+func (d *doguClient) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
+	return d.client.Delete().
+		Namespace(d.ns).
+		Resource("dogus").
+		Name(name).
+		Body(&opts).
+		Do(ctx).
+		Error()
+}
+
+// DeleteCollection deletes a collection of objects.
+func (d *doguClient) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error {
+	var timeout time.Duration
+	if listOpts.TimeoutSeconds != nil {
+		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
+	}
+	return d.client.Delete().
+		Namespace(d.ns).
+		Resource("dogus").
+		VersionedParams(&listOpts, scheme.ParameterCodec).
+		Timeout(timeout).
+		Body(&opts).
+		Do(ctx).
+		Error()
+}
+
+// Patch applies the patch and returns the patched dogu.
+func (d *doguClient) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1.Dogu, err error) {
+	result = &v1.Dogu{}
+	err = d.client.Patch(pt).
+		Namespace(d.ns).
+		Resource("dogus").
+		Name(name).
+		SubResource(subresources...).
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Body(data).
+		Do(ctx).
+		Into(result)
+	return
+}

--- a/api/ecoSystem/doguRestClient_test.go
+++ b/api/ecoSystem/doguRestClient_test.go
@@ -1,0 +1,310 @@
+package ecoSystem
+
+import (
+	"context"
+	"encoding/json"
+	k8sv1 "github.com/cloudogu/k8s-dogu-operator/api/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"io"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func Test_doguClient_Get(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		// given
+		server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			assert.Equal(t, "GET", request.Method)
+			assert.Equal(t, "/apis/k8s.cloudogu.com/v1/namespaces/test/dogus/testdogu", request.URL.Path)
+			assert.Equal(t, http.NoBody, request.Body)
+
+			writer.Header().Add("content-type", "application/json")
+			dogu := &k8sv1.Dogu{ObjectMeta: v1.ObjectMeta{Name: "testdogu", Namespace: "test"}}
+			doguBytes, err := json.Marshal(dogu)
+			require.NoError(t, err)
+			_, err = writer.Write(doguBytes)
+			require.NoError(t, err)
+			writer.WriteHeader(200)
+		}))
+
+		config := rest.Config{
+			Host: server.URL,
+		}
+		client, err := NewForConfig(&config)
+		require.NoError(t, err)
+		dClient := client.Dogus("test")
+
+		// when
+		_, err = dClient.Get(context.TODO(), "testdogu", v1.GetOptions{})
+
+		// then
+		require.NoError(t, err)
+	})
+}
+
+func Test_doguClient_List(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		// given
+		server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			assert.Equal(t, http.MethodGet, request.Method)
+			assert.Equal(t, "/apis/k8s.cloudogu.com/v1/namespaces/test/dogus", request.URL.Path)
+			assert.Equal(t, http.NoBody, request.Body)
+
+			writer.Header().Add("content-type", "application/json")
+			doguList := k8sv1.DoguList{}
+			dogu := &k8sv1.Dogu{ObjectMeta: v1.ObjectMeta{Name: "testdogu", Namespace: "test"}}
+			doguList.Items = append(doguList.Items, *dogu)
+			doguBytes, err := json.Marshal(doguList)
+			require.NoError(t, err)
+			_, err = writer.Write(doguBytes)
+			require.NoError(t, err)
+			writer.WriteHeader(200)
+		}))
+
+		config := rest.Config{
+			Host: server.URL,
+		}
+		client, err := NewForConfig(&config)
+		require.NoError(t, err)
+		dClient := client.Dogus("test")
+
+		// when
+		_, err = dClient.List(context.TODO(), v1.ListOptions{})
+
+		// then
+		require.NoError(t, err)
+	})
+}
+
+func Test_doguClient_Create(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		// given
+		dogu := &k8sv1.Dogu{ObjectMeta: v1.ObjectMeta{Name: "tocreate", Namespace: "test"}}
+
+		server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			assert.Equal(t, http.MethodPost, request.Method)
+			assert.Equal(t, "/apis/k8s.cloudogu.com/v1/namespaces/test/dogus", request.URL.Path)
+
+			bytes, err := io.ReadAll(request.Body)
+			require.NoError(t, err)
+
+			createdDogu := &k8sv1.Dogu{}
+			require.NoError(t, json.Unmarshal(bytes, createdDogu))
+			assert.Equal(t, "tocreate", createdDogu.Name)
+
+			writer.Header().Add("content-type", "application/json")
+			_, err = writer.Write(bytes)
+			require.NoError(t, err)
+			writer.WriteHeader(200)
+		}))
+
+		config := rest.Config{
+			Host: server.URL,
+		}
+		client, err := NewForConfig(&config)
+		require.NoError(t, err)
+		dClient := client.Dogus("test")
+
+		// when
+		_, err = dClient.Create(context.TODO(), dogu, v1.CreateOptions{})
+
+		// then
+		require.NoError(t, err)
+	})
+}
+
+func Test_doguClient_Update(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		// given
+		dogu := &k8sv1.Dogu{ObjectMeta: v1.ObjectMeta{Name: "tocreate", Namespace: "test"}}
+
+		server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			assert.Equal(t, http.MethodPut, request.Method)
+			assert.Equal(t, "/apis/k8s.cloudogu.com/v1/namespaces/test/dogus/tocreate", request.URL.Path)
+
+			bytes, err := io.ReadAll(request.Body)
+			require.NoError(t, err)
+
+			createdDogu := &k8sv1.Dogu{}
+			require.NoError(t, json.Unmarshal(bytes, createdDogu))
+			assert.Equal(t, "tocreate", createdDogu.Name)
+
+			writer.Header().Add("content-type", "application/json")
+			_, err = writer.Write(bytes)
+			require.NoError(t, err)
+			writer.WriteHeader(200)
+		}))
+
+		config := rest.Config{
+			Host: server.URL,
+		}
+		client, err := NewForConfig(&config)
+		require.NoError(t, err)
+		dClient := client.Dogus("test")
+
+		// when
+		_, err = dClient.Update(context.TODO(), dogu, v1.UpdateOptions{})
+
+		// then
+		require.NoError(t, err)
+	})
+}
+
+func Test_doguClient_UpdateStatus(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		// given
+		dogu := &k8sv1.Dogu{ObjectMeta: v1.ObjectMeta{Name: "tocreate", Namespace: "test"}}
+
+		server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			assert.Equal(t, http.MethodPut, request.Method)
+			assert.Equal(t, "/apis/k8s.cloudogu.com/v1/namespaces/test/dogus/tocreate/status", request.URL.Path)
+
+			bytes, err := io.ReadAll(request.Body)
+			require.NoError(t, err)
+
+			createdDogu := &k8sv1.Dogu{}
+			require.NoError(t, json.Unmarshal(bytes, createdDogu))
+			assert.Equal(t, "tocreate", createdDogu.Name)
+
+			writer.Header().Add("content-type", "application/json")
+			_, err = writer.Write(bytes)
+			require.NoError(t, err)
+			writer.WriteHeader(200)
+		}))
+
+		config := rest.Config{
+			Host: server.URL,
+		}
+		client, err := NewForConfig(&config)
+		require.NoError(t, err)
+		dClient := client.Dogus("test")
+
+		// when
+		_, err = dClient.UpdateStatus(context.TODO(), dogu, v1.UpdateOptions{})
+
+		// then
+		require.NoError(t, err)
+	})
+}
+
+func Test_doguClient_Delete(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		// given
+		server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			assert.Equal(t, http.MethodDelete, request.Method)
+			assert.Equal(t, "/apis/k8s.cloudogu.com/v1/namespaces/test/dogus/testdogu", request.URL.Path)
+
+			writer.Header().Add("content-type", "application/json")
+			writer.WriteHeader(200)
+		}))
+
+		config := rest.Config{
+			Host: server.URL,
+		}
+		client, err := NewForConfig(&config)
+		require.NoError(t, err)
+		dClient := client.Dogus("test")
+
+		// when
+		err = dClient.Delete(context.TODO(), "testdogu", v1.DeleteOptions{})
+
+		// then
+		require.NoError(t, err)
+	})
+}
+
+func Test_doguClient_DeleteCollection(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		// given
+		server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			assert.Equal(t, http.MethodDelete, request.Method)
+			assert.Equal(t, "/apis/k8s.cloudogu.com/v1/namespaces/test/dogus", request.URL.Path)
+			assert.Equal(t, "labelSelector=test", request.URL.RawQuery)
+			writer.Header().Add("content-type", "application/json")
+			writer.WriteHeader(200)
+		}))
+
+		config := rest.Config{
+			Host: server.URL,
+		}
+		client, err := NewForConfig(&config)
+		require.NoError(t, err)
+		dClient := client.Dogus("test")
+
+		// when
+		err = dClient.DeleteCollection(context.TODO(), v1.DeleteOptions{}, v1.ListOptions{LabelSelector: "test"})
+
+		// then
+		require.NoError(t, err)
+	})
+}
+
+func Test_doguClient_Patch(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		// given
+		server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			assert.Equal(t, http.MethodPatch, request.Method)
+			assert.Equal(t, "/apis/k8s.cloudogu.com/v1/namespaces/test/dogus/testdogu", request.URL.Path)
+			bytes, err := io.ReadAll(request.Body)
+			require.NoError(t, err)
+			assert.Equal(t, []byte("test"), bytes)
+			result, err := json.Marshal(k8sv1.Dogu{})
+			require.NoError(t, err)
+
+			writer.Header().Add("content-type", "application/json")
+			_, err = writer.Write(result)
+			require.NoError(t, err)
+			writer.WriteHeader(200)
+		}))
+
+		config := rest.Config{
+			Host: server.URL,
+		}
+		client, err := NewForConfig(&config)
+		require.NoError(t, err)
+		dClient := client.Dogus("test")
+
+		patchData := []byte("test")
+
+		// when
+		_, err = dClient.Patch(context.TODO(), "testdogu", types.JSONPatchType, patchData, v1.PatchOptions{})
+
+		// then
+		require.NoError(t, err)
+	})
+}
+
+func Test_doguClient_Watch(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		// given
+		server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			assert.Equal(t, "GET", request.Method)
+			assert.Equal(t, "/apis/k8s.cloudogu.com/v1/namespaces/test/dogus", request.URL.Path)
+			assert.Equal(t, http.NoBody, request.Body)
+			assert.Equal(t, "labelSelector=test&watch=true", request.URL.RawQuery)
+
+			writer.Header().Add("content-type", "application/json")
+			_, err := writer.Write([]byte("egal"))
+			require.NoError(t, err)
+			writer.WriteHeader(200)
+		}))
+
+		config := rest.Config{
+			Host: server.URL,
+		}
+		client, err := NewForConfig(&config)
+		require.NoError(t, err)
+		dClient := client.Dogus("test")
+
+		// when
+		_, err = dClient.Watch(context.TODO(), v1.ListOptions{LabelSelector: "test"})
+
+		// then
+		require.NoError(t, err)
+	})
+}

--- a/config/samples/premium/admin.yaml
+++ b/config/samples/premium/admin.yaml
@@ -1,0 +1,12 @@
+apiVersion: k8s.cloudogu.com/v1
+kind: Dogu
+metadata:
+  name: admin
+  annotations:
+    test: dev
+  labels:
+    dogu.name: admin
+    app: ces
+spec:
+  name: premium/admin
+  version: 2.6.2-1

--- a/controllers/serviceaccount/serviceaccount_creator.go
+++ b/controllers/serviceaccount/serviceaccount_creator.go
@@ -32,7 +32,7 @@ const (
 )
 
 const (
-	cesControl = "ces-control"
+	cesControl = "cesappd"
 )
 
 // creator is the unit to handle the creation of service accounts

--- a/controllers/serviceaccount/serviceaccount_creator.go
+++ b/controllers/serviceaccount/serviceaccount_creator.go
@@ -146,8 +146,16 @@ func (c *creator) createCesControlServiceAccount(ctx context.Context, dogu *core
 		return fmt.Errorf("failed to get pod for labels %v: %w", labels, err)
 	}
 
-	command := exec.NewShellCommand(fmt.Sprintf("%s service-account-create %s", cesControl, dogu.GetSimpleName()), sa.Params...)
+	var cmdParams []string
+	cmdParams = append(cmdParams, "service-account-create")
+	cmdParams = append(cmdParams, dogu.GetSimpleName())
+	cmdParams = append(cmdParams, sa.Params...)
+	command := exec.NewShellCommand("/"+cesControl+"/"+cesControl, cmdParams...)
+
 	buffer, err := c.executor.ExecCommandForPod(ctx, pod, command, internal.ContainersStarted)
+	if err != nil {
+		return fmt.Errorf("failed to exec command [%s] for pod %s: %w", command.String(), pod.Name, err)
+	}
 
 	saCreds, err := c.parseServiceCommandOutput(buffer)
 	if err != nil {

--- a/controllers/serviceaccount/serviceaccount_creator_test.go
+++ b/controllers/serviceaccount/serviceaccount_creator_test.go
@@ -155,7 +155,11 @@ func TestServiceAccountCreator_CreateServiceAccounts(t *testing.T) {
 		globalConfig := &cesmocks.ConfigurationContext{}
 		globalConfig.Mock.On("Get", "key_provider").Return("pkcs1v15", nil)
 
+		hostConfig := &cesmocks.ConfigurationContext{}
+		hostConfig.Mock.On("Exists", "redmine").Return(true, nil)
+
 		doguConfig := &cesmocks.ConfigurationContext{}
+		doguConfig.Mock.On("Exists", "sa-k8s-dogu-operator").Return(false, nil)
 		doguConfig.Mock.On("Exists", "sa-postgresql").Return(false, nil)
 		doguConfig.Mock.On("Get", "public.pem").Return(validPubKey, nil)
 		doguConfig.Mock.On("Set", "/sa-postgresql/username", mock.Anything).Return(nil)
@@ -169,6 +173,7 @@ func TestServiceAccountCreator_CreateServiceAccounts(t *testing.T) {
 		registry.Mock.On("DoguConfig", "redmine").Return(doguConfig)
 		registry.Mock.On("DoguRegistry").Return(doguRegistry)
 		registry.Mock.On("GlobalConfig").Return(globalConfig)
+		registry.Mock.On("HostConfig", "k8s-dogu-operator").Return(hostConfig)
 
 		postgresCreateSAShellCmd := exec.NewShellCommand(postgresCreateExposedCmd.Command, "redmine")
 
@@ -213,6 +218,7 @@ func TestServiceAccountCreator_CreateServiceAccounts(t *testing.T) {
 		// given
 		doguConfig := &cesmocks.ConfigurationContext{}
 		doguConfig.Mock.On("Exists", "sa-postgresql").Return(true, nil)
+		doguConfig.Mock.On("Exists", "sa-k8s-dogu-operator").Return(true, nil)
 
 		registry := &cesmocks.Registry{}
 		registry.Mock.On("DoguConfig", "redmine").Return(doguConfig)

--- a/controllers/serviceaccount/testdata/redmine-dogu-ces-sa.json
+++ b/controllers/serviceaccount/testdata/redmine-dogu-ces-sa.json
@@ -1,0 +1,143 @@
+{
+  "Name": "official/redmine",
+  "Version": "4.2.3-10",
+  "DisplayName": "Redmine",
+  "Description": "Redmine is a flexible project management web application",
+  "Category": "Development Apps",
+  "Tags": [
+    "warp",
+    "pm",
+    "projectmanagement",
+    "issue",
+    "task"
+  ],
+  "Logo": "https://cloudogu.com/images/dogus/redmine.png",
+  "Url": "http://www.redmine.org",
+  "Image": "registry.cloudogu.com/official/redmine",
+  "Dependencies": [
+    {
+      "type": "dogu",
+      "name": "postgresql"
+    },
+    {
+      "type": "dogu",
+      "name": "cas"
+    },
+    {
+      "type": "dogu",
+      "name": "nginx"
+    },
+    {
+      "type": "dogu",
+      "name": "postfix"
+    }
+  ],
+  "OptionalDependencies": [
+    {
+      "type": "package",
+      "name": "k8s-ces-control"
+    }
+  ],
+  "Configuration": [
+    {
+      "Name": "logging/root",
+      "Description": "Set the root log level to one of ERROR, WARN, INFO, DEBUG.",
+      "Optional": true,
+      "Default": "INFO",
+      "Validation": {
+        "Type": "ONE_OF",
+        "Values": [
+          "WARN",
+          "DEBUG",
+          "INFO",
+          "ERROR"
+        ]
+      }
+    },
+    {
+      "Name": "container_config/memory_limit",
+      "Description": "Limits the container's memory usage. Use a positive integer value followed by one of these units [b,k,m,g] (byte, kibibyte, mebibyte, gibibyte).",
+      "Optional": true,
+      "Validation": {
+        "Type": "BINARY_MEASUREMENT"
+      }
+    },
+    {
+      "Name": "container_config/swap_limit",
+      "Description": "Limits the container's swap memory usage. Use zero or a positive integer value followed by one of these units [b,k,m,g] (byte, kibibyte, mebibyte, gibibyte). 0 will disable swapping.",
+      "Optional": true,
+      "Validation": {
+        "Type": "BINARY_MEASUREMENT"
+      }
+    },
+    {
+      "Name": "etcd_redmine_config",
+      "Description": "Applies default configuration to redmine.",
+      "Optional": true
+    }
+  ],
+  "Volumes": [
+    {
+      "Name": "files",
+      "Path": "/usr/share/webapps/redmine/files",
+      "Owner": "1000",
+      "Group": "1000",
+      "NeedsBackup": true
+    },
+    {
+      "Name": "plugins",
+      "Path": "/var/tmp/redmine/plugins",
+      "Owner": "1000",
+      "Group": "1000",
+      "NeedsBackup": false
+    },
+    {
+      "Name": "logs",
+      "Path": "/usr/share/webapps/redmine/log",
+      "Owner": "1000",
+      "Group": "1000",
+      "NeedsBackup": false
+    }
+  ],
+  "ServiceAccounts": [
+    {
+      "Type": "postgresql"
+    },
+    {
+      "Type": "k8s-dogu-operator",
+      "Kind": "k8s",
+      "AccountName": "myTestAccount"
+    },
+    {
+      "Kind": "ces",
+      "Type": "cesappd"
+    }
+  ],
+  "HealthChecks": [
+    {
+      "Type": "tcp",
+      "Port": 3000
+    },
+    {
+      "Type": "state"
+    }
+  ],
+  "ExposedCommands": [
+    {
+      "Name": "post-upgrade",
+      "Command": "/post-upgrade.sh"
+    },
+    {
+      "Name": "upgrade-notification",
+      "Command": "/upgrade-notification.sh"
+    },
+    {
+      "Name": "pre-upgrade",
+      "Command": "/pre-upgrade.sh"
+    },
+    {
+      "Name": "delete-plugin",
+      "Command": "/delete-plugin.sh"
+    }
+  ]
+}

--- a/controllers/suite_int_test.go
+++ b/controllers/suite_int_test.go
@@ -6,6 +6,7 @@ package controllers
 import (
 	"context"
 	_ "embed"
+	"github.com/cloudogu/k8s-dogu-operator/api/ecoSystem"
 	"github.com/cloudogu/k8s-dogu-operator/controllers/exec"
 	"os"
 	"path/filepath"
@@ -44,6 +45,8 @@ import (
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 var k8sClient client.Client
+
+var k8sClientSet *ecoSystem.EcoSystemV1Alpha1Client
 var testEnv *envtest.Environment
 var cancel context.CancelFunc
 
@@ -115,6 +118,9 @@ var _ = ginkgo.BeforeSuite(func() {
 
 	k8sClient = k8sManager.GetClient()
 	gomega.Expect(k8sClient).ToNot(gomega.BeNil())
+
+	k8sClientSet, err = ecoSystem.NewForConfig(cfg)
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 	DoguRemoteRegistryMock = &cesremotemocks.Registry{}
 	EtcdDoguRegistry = &cesmocks.DoguRegistry{}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/bombsimon/logrusr/v2 v2.0.1
-	github.com/cloudogu/cesapp-lib v0.9.0
+	github.com/cloudogu/cesapp-lib v0.0.0-20221229112545-4d449f4c8473
 	github.com/cloudogu/k8s-apply-lib v0.4.0
 	github.com/go-logr/logr v1.2.3
 	github.com/google/go-cmp v0.5.8

--- a/go.sum
+++ b/go.sum
@@ -166,8 +166,8 @@ github.com/cilium/ebpf v0.4.0/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJ
 github.com/cilium/ebpf v0.6.2/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
 github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6Dob7S7YxXgwXpfOuvO54S+tGdZdw9fuRZt25Ag=
 github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
-github.com/cloudogu/cesapp-lib v0.9.0 h1:0yT7jpLKtu2X6qKG5s2UdgIojsQoyluidPRG2TwJASQ=
-github.com/cloudogu/cesapp-lib v0.9.0/go.mod h1:PTQqI3xs1ReJMXYE6BGTF33yAfmS4J7P8UiE4AwDMDY=
+github.com/cloudogu/cesapp-lib v0.0.0-20221229112545-4d449f4c8473 h1:cRZXYR4/bd+IUlBXnmlVj3kOQiluqJtwCpBiTgO6cCg=
+github.com/cloudogu/cesapp-lib v0.0.0-20221229112545-4d449f4c8473/go.mod h1:PTQqI3xs1ReJMXYE6BGTF33yAfmS4J7P8UiE4AwDMDY=
 github.com/cloudogu/k8s-apply-lib v0.4.0 h1:4jYj0gTDSvW0qs9d5yM5w8aOsMu5Sx+PBCwJwa5sMss=
 github.com/cloudogu/k8s-apply-lib v0.4.0/go.mod h1:WHCe588o8e1vzNdLGV6N4E0g7BarbPXPpW4y8U0/lxE=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=


### PR DESCRIPTION
This PR contains the following changes:

1. It provides a dogu client set that can be used to manage dogu resources in any golang application. The client provides the following methods:

```
	Create(ctx context.Context, dogu *v1.Dogu, opts metav1.CreateOptions) (*v1.Dogu, error)
	Update(ctx context.Context, dogu *v1.Dogu, opts metav1.UpdateOptions) (*v1.Dogu, error)
	UpdateStatus(ctx context.Context, dogu *v1.Dogu, opts metav1.UpdateOptions) (*v1.Dogu, error)
	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
	Get(ctx context.Context, name string, opts metav1.GetOptions) (*v1.Dogu, error)
	List(ctx context.Context, opts metav1.ListOptions) (*v1.DoguList, error)
	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)
	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1.Dogu, err error)
```

It can be created by created and used such as

```go 
doguClient, _ := ecoSystem.NewForConfig(ctrl.GetConfigOrDie())
// get a list of all installed dogu resources
doguList, _ := doguClient.Dogus("myNamespace").List(ctx, metav1.ListOptions{})
// apply a dogu to a cluster
doguList, _ := doguClient.Dogus("myNamespace").Create(ctx, myDogu, metav1.CreateOptions{})
```

2. It provides the creation of service accounts for the `k8s-ces-control`. This requires a dogu to contain the following service account definition:

```json
{
    "kind": "k8s",
    "type": "cesappd"
}
```

We kept the type cesappd for compatibility reasons with the admin dogu.