### PR TITLE
Support selfsigned certs for the dogu and docker registry.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Add optional volume mount for selfsigned cert of the dogu registry; #38
+- Add optional volume mounts for selfsigned certs of the docker and dogu registries; #81
 
 ## [v0.24.0] - 2023-02-08
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add optional volume mount for selfsigned cert of the dogu registry; #38
 
 ## [v0.24.0] - 2023-02-08
 ### Added

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -30,9 +30,11 @@ spec:
         - name: docker-registry-cert
           secret:
             secretName: docker-registry-cert
+            optional: true
         - name: dogu-registry-cert
           secret:
             secretName: dogu-registry-cert
+            optional: true
       containers:
       - args:
         - --leader-elect

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -26,9 +26,23 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
+      volumes:
+        - name: docker-registry-cert
+          secret:
+            secretName: docker-registry-cert
+        - name: dogu-registry-cert
+          secret:
+            secretName: dogu-registry-cert
       containers:
       - args:
         - --leader-elect
+        volumeMounts:
+          - name: dogu-registry-cert
+            mountPath: /etc/ssl/certs/dogu-registry-cert.pem
+            subPath: "dogu-registry-cert.pem"
+          - name: docker-registry-cert
+            mountPath: /etc/ssl/certs/docker-registry-cert.pem
+            subPath: "docker-registry-cert.pem"
         env:
           - name: STAGE
             value: "production"

--- a/docs/development/how_to_offline_and_self_signed_de.md
+++ b/docs/development/how_to_offline_and_self_signed_de.md
@@ -80,6 +80,7 @@ dogu:
 ```
 
 - `go run . sync dogu auth`
+- `go run . sync dogu`
 - `go run . sync k8s`
 
 

--- a/docs/development/how_to_offline_and_self_signed_de.md
+++ b/docs/development/how_to_offline_and_self_signed_de.md
@@ -1,0 +1,183 @@
+# Offline-Verwendung des k8s-CES mit selbst signierten Zertifikaten
+
+Dieses Dokument beschreibt stichwortartig, wie das k8s-Ecosystem mit einer lokalen Docker- und Dogu-Registry aufgesetzt
+werden kann. Bei der Verwendung ist zu beachten, dass die verwendete FQDN, Credentials des Ecosystems und die Dogu- bzw. Komponenten-Versionen
+aktuell gehalten werden.
+
+## Aufsetzen der Dogu- und Dockerregistry
+- Ecosystem aufsetzen mit Nexus-Dogu
+- FQDN als insecure registry in docker config hinzufügen `/etc/docker/daemon.json`
+- raw(hosted) Repository `mirror` und `k8s` anlegen
+
+### Komponenten spiegeln:
+
+`ces-mirror configuration.yaml`:
+
+```yaml
+version: 3
+
+k8s:
+  source:
+    components:
+      endpoint: https://dogu.cloudogu.com/api/v1/k8s
+      username: TODO
+      password: TODO
+  target:
+    registry:
+      endpoint: 192.168.56.10
+      username: ces-admin
+      password: ces-admin
+      insecure: true
+    webserver:
+      type: remote
+      endpoint: https://192.168.56.10/nexus/repository/k8s
+      username: ces-admin
+      password: ces-admin
+      insecure: true
+
+dogu:
+  dogus:
+    official/postgresql:
+      - 12.10-1
+      - 12.13-1
+    official/postfix:
+      - 3.6.4-3
+    official/ldap:
+      - 2.6.2-3
+    official/cas:
+      - 6.5.8-1
+    k8s/nginx-static:
+      - 1.23.1-3
+    k8s/nginx-ingress:
+      - 1.5.1-2
+
+  docker:
+    endpoint: unix:///var/run/docker.sock
+  source:
+    auth-backend:
+      credentials-store: ces-mirror
+      endpoint: https://account.cloudogu.com
+      proxy:
+        enabled: false
+        server: localhost
+        port: 3128
+    dogu-backend:
+      endpoint: https://dogu.cloudogu.com/api/v2/
+      credentials-store: ces-mirror
+      url-schema: default
+
+  target:
+    registry:
+      endpoint: 192.168.56.10
+      username: ces-admin
+      password: ces-admin
+      insecure: true
+    webserver:
+      type: remote
+      endpoint: https://192.168.56.10/nexus/repository/mirror
+      username: ces-admin
+      password: ces-admin
+      insecure: true
+```
+
+- `go run . sync dogu auth`
+- `go run . sync k8s`
+
+
+### Dogu-Operator in Nexus ersetzen
+
+Achtung dieser Schritt ist nicht mehr notwendig, wenn die Implementierung zur Verwendung von selbst signierten Zertifikaten
+im Dogu-Operator released wurde!
+
+Dogu-Operator yaml in Nexus ersetzen:
+- Image-Tag im Makefile ändern: IMAGE_DEV=192.168.56.10/cloudogu/${ARTIFACT_ID}:${VERSION}
+- `make k8s-generate`
+
+Nexus -> browse -> k8s:
+- delete k8s-dogu-operator/0.24.0
+Upload Component:
+- file: target/k8s-dogu-operator_0.24.0.yaml
+- filename: 0.24.0
+- directory: k8s/k8s-dogu-operator
+
+## Vorbereitung k8s-Ecosystem
+
+### K3S
+
+-  setup.json in `k8s-ecosystem` auf completed `false` setzen
+- `vagrant up`
+- Zertifikat von Ecosystem `etcdctl get config/_global/certificate/servert.crt` in `k8s-ecosystem/cert.pem` speichern
+- Zertifikat auf Maschinen verteilen (für k3s):
+  - `vagrant ssh main`
+  - `sudo cp /vagrant/cert.pem /etc/ssl/certs/cert.pem`
+  - registries.yaml bearbeiten (siehe unten)
+  - `sudo systemctl restart k3s`
+  - `vagrant ssh worker-0`
+  - `sudo cp /vagrant/cert.pem /etc/ssl/certs/cert.pem`
+  - registries.yaml bearbeiten (siehe unten)
+  - `sudo systemctl restart k3s-agent`
+
+`/etc/rancher/k3s/registries.yaml`:
+
+```yaml
+configs:
+  "192.168.56.10":
+    auth:
+      username: ces-admin
+      password: ces-admin
+    tls:
+      ca_file: /etc/ssl/certs/cert.pem
+```
+
+### Konfiguration Zertifikate und Registries 
+
+```bash
+kubectl --namespace ecosystem create secret generic docker-registry-cert --from-file=docker-registry-cert.pem=cert.pem
+```
+
+- `k8s-dogu-operator-dogu-registry` und `k8s-dogu-operator-docker-registry` löschen
+
+```bash
+kubectl --namespace ecosystem create secret generic k8s-dogu-operator-dogu-registry \
+--from-literal=endpoint="https://192.168.56.10/nexus/repository/mirror" \
+--from-literal=username="ces-admin" \
+--from-literal=password="ces-admin" \
+--from-literal=urlschema="index"
+```
+
+```bash
+kubectl --namespace ecosystem create secret docker-registry k8s-dogu-operator-docker-registry \
+ --docker-server="192.168.56.10" \
+ --docker-username="ces-admin" \
+ --docker-email="myemail@test.com" \
+ --docker-password="ces-admin"
+```
+
+### Setup aktualisieren
+
+- Setup-Config bearbeiten:
+```yaml
+#
+# The default configuration map for the ces-setup. Should always be deployed before the setup itself.
+#
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: k8s-ces-setup-config
+  labels:
+    app: ces
+    app.kubernetes.io/name: k8s-ces-setup
+data:
+  k8s-ces-setup.yaml: |
+    log_level: "DEBUG"
+    dogu_operator_url: https://192.168.56.10/nexus/repository/k8s/k8s/k8s-dogu-operator/0.24.0
+    service_discovery_url: https://192.168.56.10/nexus/repository/k8s/k8s/k8s-service-discovery/0.9.0
+    etcd_server_url: https://raw.githubusercontent.com/cloudogu/k8s-etcd/develop/manifests/etcd.yaml
+    etcd_client_image_repo: bitnami/etcd:3.5.2-debian-10-r0
+    key_provider: pkcs1v15
+```
+
+- `make build`
+
+Setup durchführen:
+- `curl -I --request POST --url http://192.168.56.2:30080/api/v1/setup`

--- a/docs/development/how_to_offline_and_self_signed_de.md
+++ b/docs/development/how_to_offline_and_self_signed_de.md
@@ -132,6 +132,7 @@ configs:
 
 ```bash
 kubectl --namespace ecosystem create secret generic docker-registry-cert --from-file=docker-registry-cert.pem=cert.pem
+kubectl --namespace ecosystem create secret generic dogu-registry-cert --from-file=dogu-registry-cert.pem=cert.pem
 ```
 
 - `k8s-dogu-operator-dogu-registry` und `k8s-dogu-operator-docker-registry` löschen

--- a/docs/development/how_to_offline_and_self_signed_de.md
+++ b/docs/development/how_to_offline_and_self_signed_de.md
@@ -2,7 +2,6 @@
 
 Dieses Dokument beschreibt stichwortartig, wie das k8s-Ecosystem mit einer lokalen Docker- und Dogu-Registry aufgesetzt
 werden kann. Bei der Verwendung ist zu beachten, dass die verwendete FQDN, Credentials des Ecosystems und die Dogu- bzw. Komponenten-Versionen
-aktuell gehalten werden.
 
 ## Aufsetzen der Dogu- und Dockerregistry
 - Ecosystem aufsetzen mit Nexus-Dogu

--- a/docs/development/how_to_offline_and_self_signed_de.md
+++ b/docs/development/how_to_offline_and_self_signed_de.md
@@ -135,7 +135,7 @@ kubectl --namespace ecosystem create secret generic docker-registry-cert --from-
 kubectl --namespace ecosystem create secret generic dogu-registry-cert --from-file=dogu-registry-cert.pem=cert.pem
 ```
 
-- `k8s-dogu-operator-dogu-registry` und `k8s-dogu-operator-docker-registry` löschen
+- Die Secrets `k8s-dogu-operator-dogu-registry` und `k8s-dogu-operator-docker-registry` löschen
 
 ```bash
 kubectl --namespace ecosystem create secret generic k8s-dogu-operator-dogu-registry \

--- a/docs/development/how_to_offline_and_self_signed_de.md
+++ b/docs/development/how_to_offline_and_self_signed_de.md
@@ -1,7 +1,7 @@
 # Offline-Verwendung des k8s-CES mit selbst signierten Zertifikaten
 
 Dieses Dokument beschreibt stichwortartig, wie das k8s-Ecosystem mit einer lokalen Docker- und Dogu-Registry aufgesetzt
-werden kann. Bei der Verwendung ist zu beachten, dass die verwendete FQDN, Credentials des Ecosystems und die Dogu- bzw. Komponenten-Versionen
+werden kann. Bei der Verwendung ist zu beachten, dass die verwendete FQDN, Credentials des Ecosystems und die Dogu- bzw. Komponenten-Versionen aktuell gehalten werden.
 
 ## Aufsetzen der Dogu- und Dockerregistry
 - Ecosystem aufsetzen mit Nexus-Dogu

--- a/docs/development/how_to_offline_and_self_signed_en.md
+++ b/docs/development/how_to_offline_and_self_signed_en.md
@@ -87,7 +87,7 @@ dogu:
 
 ### Replace dogu operator in Nexus
 
-Attention this step is no longer necessary if the implementation for using self-signed certificates
+Attention: This step is no longer necessary if the implementation for using self-signed certificates
 in the dogu operator has been released!
 
 Replace Dogu operator yaml in Nexus:

--- a/docs/development/how_to_offline_and_self_signed_en.md
+++ b/docs/development/how_to_offline_and_self_signed_en.md
@@ -1,6 +1,6 @@
 # Offline use of the k8s CES with self-signed certificates.
 
-This document describes in keywords how to set up the k8s ecosystem with a local Docker and Dogu registry.
+This document gives a brief summary on how to set up the k8s ecosystem with a local Docker and Dogu registry.
 When using it, make sure that the used FQDN, credentials of the ecosystem and the Dogu or component versions are
 kept up to date.
 

--- a/docs/development/how_to_offline_and_self_signed_en.md
+++ b/docs/development/how_to_offline_and_self_signed_en.md
@@ -133,6 +133,7 @@ configs:
 
 ```bash
 kubectl --namespace ecosystem create secret generic docker-registry-cert --from-file=docker-registry-cert.pem=cert.pem
+kubectl --namespace ecosystem create secret generic dogu-registry-cert --from-file=dogu-registry-cert.pem=cert.pem
 ```
 
 - Delete secrets `k8s-dogu-operator-dogu-registry` and `k8s-dogu-operator-docker-registry`

--- a/docs/development/how_to_offline_and_self_signed_en.md
+++ b/docs/development/how_to_offline_and_self_signed_en.md
@@ -1,0 +1,183 @@
+# Offline use of the k8s CES with self-signed certificates.
+
+This document describes in keywords how to set up the k8s ecosystem with a local Docker and Dogu registry.
+When using it, make sure that the used FQDN, credentials of the ecosystem and the Dogu or component versions are
+kept up to date.
+
+## Setting up the Dogu and Docker Registry
+- Set up ecosystem with Nexus-Dogu
+- Add FQDN as insecure registry in docker config `/etc/docker/daemon.json`.
+- Create raw(hosted) repository `mirror` and `k8s`.
+
+### Mirror components:
+
+`ces-mirror configuration.yaml`:
+
+```yaml
+version: 3
+
+k8s:
+  source:
+    components:
+      endpoint: https://dogu.cloudogu.com/api/v1/k8s
+      username: TODO
+      password: TODO
+  target:
+    registry:
+      endpoint: 192.168.56.10
+      username: ces-admin
+      password: ces-admin
+      insecure: true
+    webserver:
+      type: remote
+      endpoint: https://192.168.56.10/nexus/repository/k8s
+      username: ces-admin
+      password: ces-admin
+      insecure: true
+
+dogu:
+  dogus:
+    official/postgresql:
+      - 12.10-1
+      - 12.13-1
+    official/postfix:
+      - 3.6.4-3
+    official/ldap:
+      - 2.6.2-3
+    official/cas:
+      - 6.5.8-1
+    k8s/nginx-static:
+      - 1.23.1-3
+    k8s/nginx-ingress:
+      - 1.5.1-2
+
+  docker:
+    endpoint: unix:///var/run/docker.sock
+  source:
+    auth-backend:
+      credentials-store: ces-mirror
+      endpoint: https://account.cloudogu.com
+      proxy:
+        enabled: false
+        server: localhost
+        port: 3128
+    dogu-backend:
+      endpoint: https://dogu.cloudogu.com/api/v2/
+      credentials-store: ces-mirror
+      url-schema: default
+
+  target:
+    registry:
+      endpoint: 192.168.56.10
+      username: ces-admin
+      password: ces-admin
+      insecure: true
+    webserver:
+      type: remote
+      endpoint: https://192.168.56.10/nexus/repository/mirror
+      username: ces-admin
+      password: ces-admin
+      insecure: true
+```
+
+- `go run . sync dogu auth`
+- `go run . sync k8s`
+
+
+### Replace dogu operator in Nexus
+
+Attention this step is no longer necessary if the implementation for using self-signed certificates
+in the dogu operator has been released!
+
+Replace Dogu operator yaml in Nexus:
+- Change image tag in Makefile: IMAGE_DEV=192.168.56.10/cloudogu/${ARTIFACT_ID}:${VERSION}
+- `make k8s-generate`
+
+nexus -> browse -> k8s:
+- delete k8s-dogu-operator/0.24.0
+Upload Component:
+- file: target/k8s-dogu-operator_0.24.0.yaml
+- filename: 0.24.0
+- directory: k8s/k8s-dogu-operator
+
+## Preparation k8s-Ecosystem
+
+### K3S
+
+- Configure setup.json in `k8s-ecosystem` that any completed is `false`
+- `vagrant up`
+- Save the certificate from the ecosystem `etcdctl get config/_global/certificate/servert.crt` in `k8s-ecosystem/cert.pem`
+- Certificate distribution:
+    - `vagrant ssh main`
+    - `sudo cp /vagrant/cert.pem /etc/ssl/certs/cert.pem`
+    - Edit registries.yaml s.u.
+    - `sudo systemctl restart k3s`
+    - `vagrant ssh worker-0`
+    - `sudo cp /vagrant/cert.pem /etc/ssl/certs/cert.pem`
+    - Edit registries.yaml s.u.
+    - `sudo systemctl restart k3s-agent`
+
+`/etc/rancher/k3s/registries.yaml`:
+
+```yaml
+configs:
+  "192.168.56.10":
+    auth:
+      username: ces-admin
+      password: ces-admin
+    tls:
+      ca_file: /etc/ssl/certs/cert.pem
+```
+
+### Konfiguration certificate and registries
+
+```bash
+kubectl --namespace ecosystem create secret generic docker-registry-cert --from-file=docker-registry-cert.pem=cert.pem
+```
+
+- Delete secrets `k8s-dogu-operator-dogu-registry` and `k8s-dogu-operator-docker-registry`
+
+```bash
+kubectl --namespace ecosystem create secret generic k8s-dogu-operator-dogu-registry \
+--from-literal=endpoint="https://192.168.56.10/nexus/repository/mirror" \
+--from-literal=username="ces-admin" \
+--from-literal=password="ces-admin" \
+--from-literal=urlschema="index"
+```
+
+```bash
+kubectl --namespace ecosystem create secret docker-registry k8s-dogu-operator-docker-registry \
+ --docker-server="192.168.56.10" \
+ --docker-username="ces-admin" \
+ --docker-email="myemail@test.com" \
+ --docker-password="ces-admin"
+```
+
+### Setup refresh
+
+- Setup-Config:
+```yaml
+#
+# The default configuration map for the ces-setup. Should always be deployed before the setup itself.
+#
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: k8s-ces-setup-config
+  labels:
+    app: ces
+    app.kubernetes.io/name: k8s-ces-setup
+data:
+  k8s-ces-setup.yaml: |
+    log_level: "DEBUG"
+    dogu_operator_url: https://192.168.56.10/nexus/repository/k8s/k8s/k8s-dogu-operator/0.24.0
+    service_discovery_url: https://192.168.56.10/nexus/repository/k8s/k8s/k8s-service-discovery/0.9.0
+    etcd_server_url: https://raw.githubusercontent.com/cloudogu/k8s-etcd/develop/manifests/etcd.yaml
+    etcd_client_image_repo: bitnami/etcd:3.5.2-debian-10-r0
+    key_provider: pkcs1v15
+```
+
+- `make build`
+
+Execute setup:
+- `curl -I --request POST --url http://192.168.56.2:30080/api/v1/setup`

--- a/docs/development/how_to_offline_and_self_signed_en.md
+++ b/docs/development/how_to_offline_and_self_signed_en.md
@@ -130,7 +130,7 @@ configs:
       ca_file: /etc/ssl/certs/cert.pem
 ```
 
-### Konfiguration certificate and registries
+### Configuration certificate and registries
 
 ```bash
 kubectl --namespace ecosystem create secret generic docker-registry-cert --from-file=docker-registry-cert.pem=cert.pem

--- a/docs/development/how_to_offline_and_self_signed_en.md
+++ b/docs/development/how_to_offline_and_self_signed_en.md
@@ -155,7 +155,7 @@ kubectl --namespace ecosystem create secret docker-registry k8s-dogu-operator-do
  --docker-password="ces-admin"
 ```
 
-### Setup refresh
+### Update setup configuration
 
 - Setup-Config:
 ```yaml

--- a/docs/development/how_to_offline_and_self_signed_en.md
+++ b/docs/development/how_to_offline_and_self_signed_en.md
@@ -81,6 +81,7 @@ dogu:
 ```
 
 - `go run . sync dogu auth`
+- `go run . sync dogu`
 - `go run . sync k8s`
 
 

--- a/docs/operations/using_self_signed_certs_de.md
+++ b/docs/operations/using_self_signed_certs_de.md
@@ -1,0 +1,45 @@
+## Verwendung von selbst signierten Zertifikaten
+
+Falls die konfigurierte Docker- oder Dogu-Registry selbst signierte Zertifikate verwenden, muss man diese Mithilfe von Secrets
+konfigurieren.
+
+```bash
+kubectl --namespace <cesNamespace> create secret generic docker-registry-cert --from-file=docker-registry-cert.pem=<cert_name>.pem
+kubectl --namespace <cesNamespace> create secret generic dogu-registry-cert --from-file=dogu-registry-cert.pem=<cert_name>.pem
+```
+
+Bei einem Neustart des Controllers werden die Zertifikate nach `/etc/ssl/certs/<cert_name>.pem` gemountet und sind
+für verwendeten Http-Funktionen des Controllers verfügbar.
+
+Zusätzlich muss das Zertifikat der Docker-Registry auf allen Nodes des Clusters verteilt werden, damit Kubernetes Images pullen kann.
+Dies kann von Distribution zu Distribution unterschiedlich sein.
+
+Beispiel-Pfad Ubuntu:
+`/etc/ssl/certs/<cert_name>.pem`
+
+Bei k3s ist es außerdem erforderlich dieses Zertifikat und möglicherweise Credentials in der Konfiguration `/etc/rancher/k3s/registries.yaml` anzugeben:
+
+```yaml
+configs:
+  <RegistryURL>:
+    auth:
+      username: <username>
+      password: <password>
+    tls:
+      ca_file: /etc/ssl/certs/cert.pem
+```
+
+Es ist zu beachten, dass Credentials nicht zwingend gesetzt werden müssen, weil diese auch über die ImagePullSecrets des
+Kubernetes-Pods angegeben werden können.
+
+Anschließend muss k3s neu gestartet werden.
+
+Main-Node:
+```bash
+systemctl restart k3s
+```
+
+Worker-Node:
+```bash
+systemctl restart k3s-agent
+```

--- a/docs/operations/using_self_signed_certs_de.md
+++ b/docs/operations/using_self_signed_certs_de.md
@@ -9,7 +9,7 @@ kubectl --namespace <cesNamespace> create secret generic dogu-registry-cert --fr
 ```
 
 Bei einem Neustart des Controllers werden die Zertifikate nach `/etc/ssl/certs/<cert_name>.pem` gemountet und sind
-für verwendeten Http-Funktionen des Controllers verfügbar.
+für verwendeten Https-Funktionen des Controllers verfügbar.
 
 Zusätzlich muss das Zertifikat der Docker-Registry auf allen Nodes des Clusters verteilt werden, damit Kubernetes Images pullen kann.
 Dies kann von Distribution zu Distribution unterschiedlich sein.

--- a/docs/operations/using_self_signed_certs_en.md
+++ b/docs/operations/using_self_signed_certs_en.md
@@ -1,0 +1,44 @@
+## Using self-signed certificates
+
+If the configured Docker or Dogu registry uses self-signed certificates, you must configure them using Secrets.
+
+```bash
+kubectl --namespace <cesNamespace> create secret generic docker-registry-cert --from-file=docker-registry-cert.pem=<cert_name>.pem
+kubectl --namespace <cesNamespace> create secret generic dogu-registry-cert --from-file=dogu-registry-cert.pem=<cert_name>.pem
+```
+
+When the controller is restarted, the certificates are mounted to `/etc/ssl/certs/<cert_name>.pem` and are
+available for used Http functions of the controller.
+
+Additionally, the Docker Registry certificate must be distributed to all nodes in the cluster in order for Kubernetes to be able to pull images.
+This may vary from distribution to distribution.
+
+Example path Ubuntu:
+`/etc/ssl/certs/<cert_name>.pem`
+
+For k3s, it is also necessary to specify this certificate and possibly credentials in the `/etc/rancher/k3s/registries.yaml` configuration:
+
+```yaml
+configs:
+  <registryURL>:
+    auth:
+      username: <username>
+      password: <password>
+    tls:
+      ca_file: /etc/ssl/certs/cert.pem
+```
+
+It should be noted that credentials are not mandatory to set, because they can also be specified using the ImagePullSecrets of the
+Kubernetes pod.
+
+Afterwards, k3s must be restarted.
+
+Main node:
+```bash
+systemctl restart k3s
+```
+
+Worker node:
+```bash
+systemctl restart k3s-agent
+```

--- a/docs/operations/using_self_signed_certs_en.md
+++ b/docs/operations/using_self_signed_certs_en.md
@@ -8,7 +8,7 @@ kubectl --namespace <cesNamespace> create secret generic dogu-registry-cert --fr
 ```
 
 When the controller is restarted, the certificates are mounted to `/etc/ssl/certs/<cert_name>.pem` and are
-available for used Http functions of the controller.
+available for used Https functions of the controller.
 
 Additionally, the Docker Registry certificate must be distributed to all nodes in the cluster in order for Kubernetes to be able to pull images.
 This may vary from distribution to distribution.


### PR DESCRIPTION
It can be general necessary in development or mirrored environments to use selfsigned certificates for the dogu and docker registry. The operator is able to mount a secret with those certs.

Resolves #81 