### PR TITLE
Feature/89 stabilize image pull

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- [89] Add retry mechanism when pulling image metadata to avoid installation/upgrade interrupts when the network is not
+available.
 
 ## [v0.27.0] - 2023-03-27
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
-- [89] Add retry mechanism when pulling image metadata to avoid installation/upgrade interrupts when the network is not
-available. Moreover, increase the backoff time to 10 minutes when waiting for an exec pod to pull his image.
+- [89] Add retry mechanism when pulling image metadata to avoid installation/upgrade interrupts if errors occur. 
+Moreover, increase the backoff time to 10 minutes when waiting for an exec pod to pull the dogu image.
 
 ## [v0.27.0] - 2023-03-27
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - [89] Add retry mechanism when pulling image metadata to avoid installation/upgrade interrupts when the network is not
-available.
+available. Moreover, increase the backoff time to 10 minutes when waiting for an exec pod to pull his image.
 
 ## [v0.27.0] - 2023-03-27
 ### Added

--- a/controllers/exec/execPod.go
+++ b/controllers/exec/execPod.go
@@ -3,6 +3,7 @@ package exec
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/cloudogu/k8s-dogu-operator/internal/cloudogu"
 
@@ -22,6 +23,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
+
+var maxWaitDuration = time.Minute * 10
 
 // execPod provides features to handle files from a dogu image.
 type execPod struct {
@@ -157,7 +160,7 @@ func (ep *execPod) waitForPodToSpawn(ctx context.Context) error {
 	execPodKey := ep.ObjectKey()
 	containerPodName := execPodKey.Name
 
-	err := retry.OnError(maxTries, retry.TestableRetryFunc, func() error {
+	err := retry.OnErrorWithLimit(maxWaitDuration, retry.TestableRetryFunc, func() error {
 		pod, err := ep.getPod(ctx)
 		if err != nil {
 			logger.Error(err, fmt.Sprintf("Error while finding exec pod %s. Trying again...", containerPodName))

--- a/controllers/exec/execPod_test.go
+++ b/controllers/exec/execPod_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"testing"
+	"time"
 
 	"github.com/cloudogu/k8s-dogu-operator/internal/cloudogu"
 
@@ -117,8 +118,8 @@ func Test_execPod_Create(t *testing.T) {
 	})
 	t.Run("should fail on other pod status", func(t *testing.T) {
 		// given
-		originalMaxTries := maxTries
-		maxTries = 1
+		originalMaxWaitDuration := maxWaitDuration
+		maxWaitDuration = time.Second * 3
 		mockClient := extMocks.NewK8sClient(t)
 		objectKey := client.ObjectKey{Namespace: testNamespace, Name: podName}
 		clientGetFn := func(args mock.Arguments) {
@@ -139,12 +140,12 @@ func Test_execPod_Create(t *testing.T) {
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "failed to wait for exec pod test-execpod-123abc to spawn")
 		assert.ErrorContains(t, err, "found exec pod test-execpod-123abc but with status phase Pending")
-		maxTries = originalMaxTries
+		maxWaitDuration = originalMaxWaitDuration
 	})
 	t.Run("should fail on unable to find pod", func(t *testing.T) {
 		// given
-		originalMaxTries := maxTries
-		maxTries = 1
+		originalMaxWaitDuration := maxWaitDuration
+		maxWaitDuration = time.Second * 3
 		mockClient := extMocks.NewK8sClient(t)
 		objectKey := client.ObjectKey{Namespace: testNamespace, Name: podName}
 		mockClient.
@@ -160,7 +161,7 @@ func Test_execPod_Create(t *testing.T) {
 		// then
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "failed to wait for exec pod test-execpod-123abc to spawn")
-		maxTries = originalMaxTries
+		maxWaitDuration = originalMaxWaitDuration
 	})
 	t.Run("should succeed", func(t *testing.T) {
 		// given

--- a/controllers/imageregistry/image_registry.go
+++ b/controllers/imageregistry/image_registry.go
@@ -3,10 +3,17 @@ package imageregistry
 import (
 	"context"
 	"fmt"
+	"github.com/cloudogu/k8s-dogu-operator/retry"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/crane"
 	imagev1 "github.com/google/go-containerregistry/pkg/v1"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"strings"
 )
+
+const errMsgNoNetwork = "connect: network is unreachable"
+
+var ImagePull = crane.Pull
 
 // craneContainerImageRegistry is a component to interact with a container registry.
 // It is able to pull the config of an image and uses the crane library
@@ -30,9 +37,24 @@ func (i *craneContainerImageRegistry) PullImageConfig(ctx context.Context, image
 		Username: i.dockerUsername,
 		Password: i.dockerPassword,
 	})
-	img, err := crane.Pull(image, authOpts, ctxOpt)
+
+	logger := log.FromContext(ctx)
+	logger.Info(fmt.Sprintf("Try to pull image manifest from image: [%s]", image))
+
+	var img imagev1.Image
+	err := retry.OnError(15, retry.TestableRetryFunc, func() (err error) {
+		img, err = ImagePull(image, authOpts, ctxOpt)
+		if err != nil && strings.Contains(err.Error(), errMsgNoNetwork) {
+			logger.Error(err, "Retry because the network is not reachable")
+			return &retry.TestableRetrierError{}
+		}
+
+		return
+	})
+
 	if err != nil {
 		return nil, fmt.Errorf("error pulling image: %w", err)
 	}
+
 	return img.ConfigFile()
 }

--- a/docs/development/event_policy_for_the_operator_de.md
+++ b/docs/development/event_policy_for_the_operator_de.md
@@ -34,6 +34,7 @@ erfolgreiche Installation, um einen guten Überblick über die Granularität des
 ![Bild mit Ereignissen für die erfolgreiche Installation des `postgresql` Dogu.](figures/events_without_errors.png)
 
 ## Verwendung von Ereignissen im `k8s-dogu-operator`
-
+<!-- TODO Please check this link because actual kubebuilder has ssl issues -->
+<!-- markdown-link-check-disable -->
 Die [kubebuilder Dokumentation](https://book-v1.book.kubebuilder.io/beyond_basics/creating_events.html) erklärt, wie man
 Events innerhalb eines Kubernetes-Controllers verwendet.

--- a/docs/development/event_policy_for_the_operator_de.md
+++ b/docs/development/event_policy_for_the_operator_de.md
@@ -34,7 +34,9 @@ erfolgreiche Installation, um einen guten Überblick über die Granularität des
 ![Bild mit Ereignissen für die erfolgreiche Installation des `postgresql` Dogu.](figures/events_without_errors.png)
 
 ## Verwendung von Ereignissen im `k8s-dogu-operator`
-<!-- TODO Please check this link because actual kubebuilder has ssl issues -->
-<!-- markdown-link-check-disable -->
-Die [kubebuilder Dokumentation](https://book-v1.book.kubebuilder.io/beyond_basics/creating_events.html) erklärt, wie man
-Events innerhalb eines Kubernetes-Controllers verwendet.
+
+Events können mit einem [EventRecoder](https://pkg.go.dev/k8s.io/client-go/tools/record#EventRecorder) an 
+Dogu-Ressourcen geschrieben werden. Der Manager implementiert das Interface 
+[Cluster](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/cluster#Cluster). Die darin enthaltene Methode
+`GetEventRecorderFor(name string)` liefert eine Referenz zu einem EventRecorder-Objekt.
+Die Verwendung kann zum Beispiel in dem Installation-Manager des `k8s-dogu-operator` betrachtet werden.

--- a/docs/development/event_policy_for_the_operator_en.md
+++ b/docs/development/event_policy_for_the_operator_en.md
@@ -32,6 +32,7 @@ overview about the granularity used in the `k8s-dogu-operator`.
 ![Image depicting events for successful `postgresql` dogu installation.](figures/events_without_errors.png)
 
 ## Using events in the `k8s-dogu-operator`
-
+<!-- TODO Please check this link because actual kubebuilder has ssl issues -->
+<!-- markdown-link-check-disable -->
 The [kubebuilder documentation](https://book-v1.book.kubebuilder.io/beyond_basics/creating_events.html) explains
 perfectly how to use events inside a kubernetes controller.

--- a/docs/development/event_policy_for_the_operator_en.md
+++ b/docs/development/event_policy_for_the_operator_en.md
@@ -32,7 +32,9 @@ overview about the granularity used in the `k8s-dogu-operator`.
 ![Image depicting events for successful `postgresql` dogu installation.](figures/events_without_errors.png)
 
 ## Using events in the `k8s-dogu-operator`
-<!-- TODO Please check this link because actual kubebuilder has ssl issues -->
-<!-- markdown-link-check-disable -->
-The [kubebuilder documentation](https://book-v1.book.kubebuilder.io/beyond_basics/creating_events.html) explains
-perfectly how to use events inside a kubernetes controller.
+
+Events can be written with an [EventRecoder](https://pkg.go.dev/k8s.io/client-go/tools/record#EventRecorder) to
+Dogu resources. The manager implements the interface
+[Cluster](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/cluster#Cluster). The method contained in it
+`GetEventRecorderFor(name string)` returns a reference to an EventRecorder object.
+The usage can be seen for example in the installation manager of the `k8s-dogu-operator`.


### PR DESCRIPTION
Stabilize the installation and upgrade procedure with a retry mechanism when pulling the container image with the dogu operator. Moreover, increase the backoff time from the exec pod to ensure that install/upgrades with slow connections don't get interrupted.

Resolves #89 