### PR TITLE
fix SonarQube findings: delete dead code, simplify if-return

### DIFF
--- a/controllers/cesregistry/dogu_registrator.go
+++ b/controllers/cesregistry/dogu_registrator.go
@@ -135,10 +135,10 @@ func (c *CesDoguRegistrator) registerNewKeys(ctx context.Context, doguResource *
 		return c.createKeyPair(ctx, doguResource, dogu, keyProvider)
 	}
 
-	return c.recreatePubKey(secret, err, keyProvider, dogu)
+	return c.recreatePubKey(secret, keyProvider, dogu)
 }
 
-func (c *CesDoguRegistrator) recreatePubKey(secret *corev1.Secret, err error, keyProvider *keys.KeyProvider, dogu *core.Dogu) error {
+func (c *CesDoguRegistrator) recreatePubKey(secret *corev1.Secret, keyProvider *keys.KeyProvider, dogu *core.Dogu) error {
 	existingPrivateKey := secret.Data["private.pem"]
 	keyPair, err := keyProvider.FromPrivateKey(existingPrivateKey)
 	if err != nil {

--- a/controllers/doguDeleteManager.go
+++ b/controllers/doguDeleteManager.go
@@ -25,10 +25,8 @@ const finalizerName = "dogu-finalizer"
 type doguDeleteManager struct {
 	client                client.Client
 	localDoguFetcher      cloudogu.LocalDoguFetcher
-	imageRegistry         cloudogu.ImageRegistry
 	doguRegistrator       cloudogu.DoguRegistrator
 	serviceAccountRemover cloudogu.ServiceAccountRemover
-	doguSecretHandler     cloudogu.DoguSecretHandler
 	exposedPortRemover    cloudogu.ExposePortRemover
 	eventRecorder         record.EventRecorder
 }

--- a/controllers/doguDeleteManager_test.go
+++ b/controllers/doguDeleteManager_test.go
@@ -39,7 +39,6 @@ func getDoguDeleteManagerWithMocks(t *testing.T) doguDeleteManagerWithMocks {
 	doguDeleteManager := &doguDeleteManager{
 		client:                k8sClient,
 		localDoguFetcher:      doguFetcher,
-		imageRegistry:         imageRegistry,
 		doguRegistrator:       doguRegistrator,
 		serviceAccountRemover: serviceAccountRemover,
 		exposedPortRemover:    exposedPortRemover,

--- a/controllers/doguInstallManager.go
+++ b/controllers/doguInstallManager.go
@@ -14,8 +14,6 @@ import (
 
 	cesappcore "github.com/cloudogu/cesapp-lib/core"
 	cesregistry "github.com/cloudogu/cesapp-lib/registry"
-	cesremote "github.com/cloudogu/cesapp-lib/remote"
-
 	k8sv1 "github.com/cloudogu/k8s-dogu-operator/api/v1"
 	"github.com/cloudogu/k8s-dogu-operator/controllers/config"
 	"github.com/cloudogu/k8s-dogu-operator/controllers/dependency"
@@ -33,8 +31,6 @@ const k8sDoguOperatorFieldManagerName = "k8s-dogu-operator"
 type doguInstallManager struct {
 	client                thirdParty.K8sClient
 	recorder              record.EventRecorder
-	doguRemoteRegistry    cesremote.Registry
-	doguLocalRegistry     cesregistry.DoguRegistry
 	localDoguFetcher      cloudogu.LocalDoguFetcher
 	resourceDoguFetcher   cloudogu.ResourceDoguFetcher
 	imageRegistry         cloudogu.ImageRegistry

--- a/controllers/resource/resource_generator.go
+++ b/controllers/resource/resource_generator.go
@@ -9,7 +9,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/cloudogu/cesapp-lib/core"
@@ -217,25 +216,6 @@ func buildDeploymentSpec(selectorLabels map[string]string, podTemplate *corev1.P
 		},
 		Template: *podTemplate,
 	}
-}
-
-func createLivenessProbe(dogu *core.Dogu) *corev1.Probe {
-	for _, healthCheck := range dogu.HealthChecks {
-		if healthCheck.Type == "tcp" {
-			return &corev1.Probe{
-				ProbeHandler: corev1.ProbeHandler{
-					TCPSocket: &corev1.TCPSocketAction{Port: intstr.IntOrString{IntVal: int32(healthCheck.Port)}},
-				},
-				TimeoutSeconds:   1,
-				PeriodSeconds:    10,
-				SuccessThreshold: 1,
-				// Setting this value to low makes some dogus unable to start that require a certain amount of time.
-				// The default value is set to 30 min.
-				FailureThreshold: 6 * 30,
-			}
-		}
-	}
-	return nil
 }
 
 // CreateStartupProbe returns a container start-up probe for the given dogu if it contains a state healthcheck.

--- a/controllers/resource/resource_generator_test.go
+++ b/controllers/resource/resource_generator_test.go
@@ -24,6 +24,8 @@ import (
 
 var testAdditionalImages = map[string]string{"chownInitImage": "busybox:1.36"}
 
+const testChownInitContainerImage = "busybox:1.36"
+
 func TestNewResourceGenerator(t *testing.T) {
 	// given
 	registry := cesmocks.NewRegistry(t)
@@ -326,23 +328,6 @@ func TestResourceGenerator_GetDoguSecret(t *testing.T) {
 		assert.ErrorContains(t, err, "failed to set controller reference:")
 	})
 }
-
-func Test_createLivenessProbe(t *testing.T) {
-	t.Run("should should return nil for a dogu without tcp probes", func(t *testing.T) {
-		dogu := readLdapDogu(t)
-		dogu.HealthChecks = []core.HealthCheck{{
-			Type: "http",
-		}}
-
-		// when
-		actual := createLivenessProbe(dogu)
-
-		// then
-		require.Nil(t, actual)
-	})
-}
-
-const testChownInitContainerImage = "busybox:1.36"
 
 func Test_getChownInitContainer(t *testing.T) {
 	t.Run("success with whitespace in volume path", func(t *testing.T) {

--- a/controllers/resource/upserter.go
+++ b/controllers/resource/upserter.go
@@ -147,11 +147,7 @@ func (u *upserter) waitForExistingPVCToBeTerminated(ctx context.Context, pvcObje
 }
 
 func pvcRetry(err error) bool {
-	if strings.Contains(err.Error(), errMsgFailedToGetPVC) {
-		return false
-	}
-
-	return true
+	return !strings.Contains(err.Error(), errMsgFailedToGetPVC)
 }
 
 func (u *upserter) updateOrInsert(ctx context.Context, objectKey client.ObjectKey,

--- a/controllers/suite_int_test.go
+++ b/controllers/suite_int_test.go
@@ -1,5 +1,4 @@
 //go:build k8s_integration
-// +build k8s_integration
 
 package controllers
 
@@ -184,8 +183,6 @@ var _ = ginkgo.BeforeSuite(func() {
 		client:                k8sClient,
 		recorder:              eventRecorder,
 		resourceUpserter:      upserter,
-		doguRemoteRegistry:    DoguRemoteRegistryMock,
-		doguLocalRegistry:     EtcdDoguRegistry,
 		resourceDoguFetcher:   remoteDoguFetcher,
 		imageRegistry:         ImageRegistryMock,
 		doguRegistrator:       doguRegistrator,
@@ -200,10 +197,8 @@ var _ = ginkgo.BeforeSuite(func() {
 
 	deleteManager := &doguDeleteManager{
 		client:                k8sClient,
-		imageRegistry:         ImageRegistryMock,
 		doguRegistrator:       doguRegistrator,
 		serviceAccountRemover: serviceAccountRemover,
-		doguSecretHandler:     doguSecretHandler,
 		localDoguFetcher:      localDoguFetcher,
 		exposedPortRemover:    exposedPortRemover,
 	}


### PR DESCRIPTION
These static analysis findings accumulated over the time of a year.