### PR TITLE
#149 add escape rules to support every special char

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,7 +1,7 @@
 # Usage:
 # 1. Copy this file as `.env` into your project
 # 2. Adapt the information below with the your personal data.
-# 3. INFO: escape special characters like # with \
+# 3. INFO: escape special characters (see rules below)
 #
 # The file `.env` is ignored by git. Note: DO NOT COMMIT your personal data.
 
@@ -10,15 +10,43 @@
 export LOG_LEVEL=debug
 export NAMESPACE=$(shell kubectl config view --minify -o jsonpath='{..namespace}')
 
+##### Depending on your use case, you need different escaping strategies:
+##### 1. If you want to start the dogu operator with `make run` (uses normal environment variables):
+
 # Credentials for the dogu registry. Do not use quotes for the values.
 export DOGU_REGISTRY_ENDPOINT=https://dogu.cloudogu.com/api/v2/dogus
 export DOGU_REGISTRY_USERNAME=<doguRegistryUsername>
-# INFO: escape special characters like # with \
+# INFO: escape the special characters for Env-File & Makefile: # with \ and $ with $$
+# example: 0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~ \t\n\r\x0b\x0c
+# escaped: 0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!"\#$$%&'()*+,-./:;<=>?@[\]^_`{|}~ \t\n\r\x0b\x0c
 export DOGU_REGISTRY_PASSWORD=<doguRegistryPassword>
 
 # Credentials for the docker registry. Do not use quotes for the values.
 docker_registry_server=<dockerRegistryServer>
 docker_registry_username=<dockerRegistryUsername>
-# INFO: escape special characters like # with \
+# INFO: escaping is different, depending on your use case.
+# Info: escape the special characters for Env-File, Makefile & JSON: ",#,\ with \ and $ with $$
+# example: 0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~ \t\n\r\x0b\x0c
+# escaped: 0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!\"\#$$%&'()*+,-./:;<=>?@[\\]^_`{|}~ \\t\\n\\r\\x0b\\x0c
 docker_registry_password=<dockerRegistryPassword>
 export DOCKER_REGISTRY={"auths":{"${docker_registry_server}":{"username":"${docker_registry_username}","password":"${docker_registry_password}","email":"ignore@me.com","auth":"ignoreMe"}}}
+
+##### 2. If you want to to use `make print-debug-info` and start the dogu operator with intelliJ (e.g. for debugging)
+#####n (set environment via run-configuration):
+
+## Credentials for the dogu registry. Do not use quotes for the values.
+#DOGU_REGISTRY_ENDPOINT=https://dogu.cloudogu.com/api/v2/dogus
+#DOGU_REGISTRY_USERNAME=<doguRegistryUsername>
+## INFO: escape the special characters for Env-File, Makefile & Shell: #,",` with \ and $ with $$
+## example: 0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~ \t\n\r\x0b\x0c
+## escaped: 0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!\"\#$$%&'()*+,-./:;<=>?@[\]^_\`{|}~ \t\n\r\x0b\x0c
+#DOGU_REGISTRY_PASSWORD=<doguRegistryPassword>
+#
+## Credentials for the docker registry. Do not use quotes for the values.
+#docker_registry_server=<dockerRegistryServer>
+#docker_registry_username=<dockerRegistryUsername>
+## INFO: escaping is different, depending on your use case.
+## Info: escape the special characters for Env-File, Makefile, Shell & JSON: #,` with \, " with \\\", \ with \\\ and $ with $$
+## example: 0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~ \t\n\r\x0b\x0c
+## escaped: 0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!\\\"\#$$%&'()*+,-./:;<=>?@[\\\]^_\`{|}~ \\\t\\\n\\\r\\\x0b\\\x0c
+#docker_registry_password=<dockerRegistryPassword>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Added
+- [#54] Clarified escaping rules for running the operator locally
+  (see [here](docs/development/development_guide_en.md) or [here](.env.template)) #64
+- 
 ## [v0.41.0] - 2024-01-23
 ### Changed
 - Update go dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- [#54] Clarified escaping rules for running the operator locally
-  (see [here](docs/development/development_guide_en.md) or [here](.env.template)) #64
-- 
+- [#149] Clarified escaping rules for running the operator locally
+  (see [here](docs/development/development_guide_en.md) or [here](.env.template))
+
 ## [v0.41.0] - 2024-01-23
 ### Changed
 - Update go dependencies

--- a/config/debug/Readme.md
+++ b/config/debug/Readme.md
@@ -1,0 +1,4 @@
+# Debugging resources
+
+These resources are necessary for debugging the operator locally.
+See [the corresponding docs](/docs/development/development_guide_en.md).

--- a/config/debug/additional-images-configmap.yaml
+++ b/config/debug/additional-images-configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: k8s-dogu-operator-additional-images
+data:
+  chownInitImage: "busybox:1.36"

--- a/docs/development/development_guide_de.md
+++ b/docs/development/development_guide_de.md
@@ -13,6 +13,14 @@
 6. Löschen Sie eventuelle Dogu-Operator-Deployments im Cluster, um Parallelisierungsfehler auszuschließen
    - `kubectl delete deployment k8s-dogu-operator`
 
+### Debugging mit IntelliJ
+
+1. Folgen Sie die oben beschriebenen Schritte, mit Ausnahme von `make run`
+2. Benutzen Sie den Abschnitt zu IntelliJ aus dem .env-template
+3. Lassen Sie sich Ihre Umgebungsvariablen mit `make print-debug-info` ausgeben
+4. Kopieren Sie sich das Ergebnis in Ihre intelliJ Startkonfiguration
+5. Starten Sie die main.go im Debug-mode
+
 ## Makefile-Targets
 
 Der Befehl `make help` gibt alle verfügbaren Targets und deren Beschreibungen in der Kommandozeile aus.

--- a/docs/development/development_guide_de.md
+++ b/docs/development/development_guide_de.md
@@ -9,9 +9,11 @@
    Umgebungsvariablendatei mit persönlichen Informationen anzulegen
 4. Erzeugen Sie einen etcd Port-Forward
    - `kubectl -n=ecosystem port-forward etcd-0 4001:2379`
-5. Führen Sie `make run` aus, um den dogu-Operator lokal auszuführen
-6. Löschen Sie eventuelle Dogu-Operator-Deployments im Cluster, um Parallelisierungsfehler auszuschließen
-   - `kubectl delete deployment k8s-dogu-operator`
+5. Löschen Sie den Dogu-Operator im Cluster, um Parallelisierungsfehler auszuschließen
+   - `kubectl delete component k8s-dogu-operator`
+6. Erstellen Sie benötigte Debugging-Ressourcen:
+   - `kubectl apply -f config/debug`
+7. Führen Sie `make run` aus, um den dogu-Operator lokal auszuführen
 
 ### Debugging mit IntelliJ
 

--- a/docs/development/development_guide_en.md
+++ b/docs/development/development_guide_en.md
@@ -12,6 +12,14 @@
 6. Delete any existing dogu operator deployments to avoid concurrency issues
    - `kubectl -n=ecosystem delete deployment k8s-dogu-operator`
 
+### Debugging with IntelliJ
+
+1. Follow steps above except `make run`
+2. Use the IntelliJ-section of the .env-template
+3. print your set of env-variables with `make print-debug-info`
+4. copy the result in your intelliJ run configuration as environment
+5. start main.go in debug-mode
+
 ## Makefile-Targets
 
 The command `make help` prints all available targets and their descriptions in the command line.

--- a/docs/development/development_guide_en.md
+++ b/docs/development/development_guide_en.md
@@ -8,9 +8,11 @@
 3. Open the file `.env.template` and follow the instructions to create an env file with your personal data
 4. Make an etcd port forward
    - `kubectl -n=ecosystem port-forward etcd-0 4001:2379`
-5. Run `make run` to run the dogu operator locally
-6. Delete any existing dogu operator deployments to avoid concurrency issues
-   - `kubectl -n=ecosystem delete deployment k8s-dogu-operator`
+5. Delete the existing dogu operator from the cluster to avoid concurrency issues
+   - `kubectl delete component k8s-dogu-operator`
+6. Create necessary debug resources:
+   - `kubectl apply -f config/debug`
+7. Run `make run` to run the dogu operator locally
 
 ### Debugging with IntelliJ
 


### PR DESCRIPTION
The CES-Setup and Vagrantfile were not working with some special characters, so we use base64 and escaping rules to make every password work.

Resolves #149 