### PR TITLE
Fix dogu health

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (see [here](docs/development/development_guide_en.md) or [here](.env.template))
 
 ### Fixed
-- [#152] Fix a bug where the health routine marked a dogu as available if the deployment was scaled to 0.
+- [#152] The health routine no longer marks a dogu as available if the deployment was scaled to 0.
 
 ## [v0.41.0] - 2024-01-23
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#149] Clarified escaping rules for running the operator locally
   (see [here](docs/development/development_guide_en.md) or [here](.env.template))
 
+### Fixed
+- [#152] Fix a bug where the health routine marked a dogu as available if the deployment was scaled to 0.
+
 ## [v0.41.0] - 2024-01-23
 ### Changed
 - Update go dependencies

--- a/controllers/health/availability.go
+++ b/controllers/health/availability.go
@@ -9,16 +9,20 @@ type AvailabilityChecker struct{}
 // IsAvailable checks whether the deployment has reached its desired state and is available.
 func (ac *AvailabilityChecker) IsAvailable(deployment *appsv1.Deployment) bool {
 	// if replicas is nil, it is defaulted to 1
-	if deployment.Spec.Replicas == nil && deployment.Status.UpdatedReplicas < 1 {
+	status := deployment.Status
+	if deployment.Spec.Replicas == nil && status.UpdatedReplicas < 1 {
 		return false
 	}
-	if deployment.Spec.Replicas != nil && deployment.Status.UpdatedReplicas < *deployment.Spec.Replicas {
+	if deployment.Spec.Replicas != nil && status.UpdatedReplicas < *deployment.Spec.Replicas {
 		return false
 	}
-	if deployment.Status.Replicas > deployment.Status.UpdatedReplicas {
+	if deployment.Spec.Replicas != nil && *deployment.Spec.Replicas == 0 {
 		return false
 	}
-	if deployment.Status.AvailableReplicas < deployment.Status.UpdatedReplicas {
+	if status.Replicas > status.UpdatedReplicas {
+		return false
+	}
+	if status.AvailableReplicas < status.UpdatedReplicas {
 		return false
 	}
 

--- a/controllers/health/availability_test.go
+++ b/controllers/health/availability_test.go
@@ -8,6 +8,7 @@ import (
 
 func TestAvailabilityChecker_IsAvailable(t *testing.T) {
 	var one int32 = 1
+	var zero int32 = 0
 	tests := []struct {
 		name       string
 		deployment *appsv1.Deployment
@@ -36,6 +37,11 @@ func TestAvailabilityChecker_IsAvailable(t *testing.T) {
 		{
 			name:       "should return false if available replicas is less than updated replicas",
 			deployment: &appsv1.Deployment{Status: appsv1.DeploymentStatus{Replicas: 1, UpdatedReplicas: 1, AvailableReplicas: 0}},
+			want:       false,
+		},
+		{
+			name:       "should return false if deployment is scaled to 0",
+			deployment: &appsv1.Deployment{Spec: appsv1.DeploymentSpec{Replicas: &zero}},
 			want:       false,
 		},
 		{


### PR DESCRIPTION
The checker for availability did check if a dogu is rolled out. This was true if a deployment is scaled to 0. For availability add this as an edge-case.

Resolves #152 