### PR TITLE
Add validation for dogu volume size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#149] Clarified escaping rules for running the operator locally
   (see [here](docs/development/development_guide_en.md) or [here](.env.template))
 
+### Changed
+- [#154] Only accept dogu volume sizes in binary format.
+
 ## [v0.41.0] - 2024-01-23
 ### Changed
 - Update go dependencies

--- a/controllers/dogu_controller.go
+++ b/controllers/dogu_controller.go
@@ -495,7 +495,7 @@ func (r *doguReconciler) validateVolumeSize(doguResource *k8sv1.Dogu) (success b
 	}
 
 	if quantity.Format != resource.BinarySI {
-		r.recorder.Eventf(doguResource, v1.EventTypeWarning, FailedVolumeSizeSIValidationEventReason, "Dogu resource volume size format is not Binary-SI: %s", quantity)
+		r.recorder.Eventf(doguResource, v1.EventTypeWarning, FailedVolumeSizeSIValidationEventReason, "Dogu resource volume size format is not Binary-SI ("Mi" or "Gi"): %s", quantity)
 		return false
 	}
 

--- a/controllers/dogu_controller.go
+++ b/controllers/dogu_controller.go
@@ -495,7 +495,7 @@ func (r *doguReconciler) validateVolumeSize(doguResource *k8sv1.Dogu) (success b
 	}
 
 	if quantity.Format != resource.BinarySI {
-		r.recorder.Eventf(doguResource, v1.EventTypeWarning, FailedVolumeSizeSIValidationEventReason, "Dogu resource volume size format is not Binary-SI ("Mi" or "Gi"): %s", quantity)
+		r.recorder.Eventf(doguResource, v1.EventTypeWarning, FailedVolumeSizeSIValidationEventReason, "Dogu resource volume size format is not Binary-SI (\"Mi\" or \"Gi\"): %s", quantity)
 		return false
 	}
 

--- a/controllers/dogu_controller.go
+++ b/controllers/dogu_controller.go
@@ -54,7 +54,9 @@ const (
 )
 
 const (
-	FailedNameValidationEventReason = "FailedNameValidation"
+	FailedNameValidationEventReason              = "FailedNameValidation"
+	FailedVolumeSizeParsingValidationEventReason = "FailedVolumeSizeParsingValidation"
+	FailedVolumeSizeSIValidationEventReason      = "FailedVolumeSizeSIValidation"
 )
 
 const handleRequeueErrMsg = "failed to handle requeue: %w"
@@ -122,8 +124,8 @@ func (r *doguReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	}
 	logger.Info(fmt.Sprintf("Dogu %s/%s has been found", doguResource.Namespace, doguResource.Name))
 
-	hasValidName := r.validateName(doguResource)
-	if !hasValidName {
+	valid := r.validateDogu(doguResource)
+	if !valid {
 		return finishOperation()
 	}
 
@@ -140,6 +142,13 @@ func (r *doguReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	}
 
 	return r.executeRequiredOperation(ctx, requiredOperations, doguResource)
+}
+
+func (r *doguReconciler) validateDogu(doguResource *k8sv1.Dogu) bool {
+	hasValidName := r.validateName(doguResource)
+	hasValidVolumeSize := r.validateVolumeSize(doguResource)
+
+	return hasValidName && hasValidVolumeSize
 }
 
 func (r *doguReconciler) executeRequiredOperation(ctx context.Context, requiredOperations []operation, doguResource *k8sv1.Dogu) (ctrl.Result, error) {
@@ -467,6 +476,26 @@ func (r *doguReconciler) validateName(doguResource *k8sv1.Dogu) (success bool) {
 
 	if doguResource.Name != simpleName {
 		r.recorder.Eventf(doguResource, v1.EventTypeWarning, FailedNameValidationEventReason, "Dogu resource does not follow naming rules: The dogu's simple name '%s' must be the same as the resource name '%s'.", simpleName, doguResource.Name)
+		return false
+	}
+
+	return true
+}
+
+func (r *doguReconciler) validateVolumeSize(doguResource *k8sv1.Dogu) (success bool) {
+	size := doguResource.Spec.Resources.DataVolumeSize
+	if len(size) == 0 {
+		return true
+	}
+
+	quantity, err := resource.ParseQuantity(size)
+	if err != nil {
+		r.recorder.Eventf(doguResource, v1.EventTypeWarning, FailedVolumeSizeParsingValidationEventReason, "Dogu resource volume size parsing error: %s", size)
+		return false
+	}
+
+	if quantity.Format != resource.BinarySI {
+		r.recorder.Eventf(doguResource, v1.EventTypeWarning, FailedVolumeSizeSIValidationEventReason, "Dogu resource volume size format is not Binary-SI: %s", quantity)
 		return false
 	}
 

--- a/controllers/dogu_controller_test.go
+++ b/controllers/dogu_controller_test.go
@@ -1161,7 +1161,7 @@ func Test_doguReconciler_validateVolumeSize(t *testing.T) {
 			args: args{doguResource: &k8sv1.Dogu{Spec: k8sv1.DoguSpec{Resources: k8sv1.DoguResources{DataVolumeSize: "2G"}}}},
 			recorderFunc: func(t *testing.T) record.EventRecorder {
 				recorder := extMocks.NewEventRecorder(t)
-				recorder.EXPECT().Eventf(mock.Anything, "Warning", "FailedVolumeSizeSIValidation", "Dogu resource volume size format is not Binary-SI: %s", resource.MustParse("2G"))
+				recorder.EXPECT().Eventf(mock.Anything, "Warning", "FailedVolumeSizeSIValidation", "Dogu resource volume size format is not Binary-SI (\"Mi\" or \"Gi\"): %s", resource.MustParse("2G"))
 				return recorder
 			},
 			wantSuccess: false,

--- a/docs/operations/expand_volume_de.md
+++ b/docs/operations/expand_volume_de.md
@@ -17,6 +17,8 @@ spec:
     dataVolumeSize: 2Gi
 ```
 
+> Die Größen der Volumes müssen im binären Format angegeben werden (z.B. Mi oder Gi).
+
 Setzt man `dataVolumeSize` und aktualisiert die Dogu-Ressource wird der Prozess zum Vergrößern des Volumes gestartet.
 
 Zu beachten ist, dass der Wert von `dataVolumeSize` der Norm von 

--- a/docs/operations/expand_volume_en.md
+++ b/docs/operations/expand_volume_en.md
@@ -16,6 +16,8 @@ spec:
     dataVolumeSize: 2Gi
 ```
 
+> The sizes of the volumes must be specified in binary format (e.g. Mi or Gi).
+
 Setting `dataVolumeSize` and updating the Dogu resource will start the process to increase the volume size.
 
 Note that the value of `dataVolumeSize` must match the norm of 


### PR DESCRIPTION
If a volume size for a dogu is specified, the operator only accepts binary formats. This was added because storage-provisioner always convert the quantities in binary format and round up the values. This leads to inconsistent data between the dogu cr and the real pvc.

Resolves #154