### PR TITLE
Stabilized process when updating the status of the dogu cr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#149] Clarified escaping rules for running the operator locally
   (see [here](docs/development/development_guide_en.md) or [here](.env.template))
 
+### Changed
+- [#156] Stabilized process when updating the status of the dogu cr.
+
 ## [v0.41.0] - 2024-01-23
 ### Changed
 - Update go dependencies

--- a/api/v1/dogu_types.go
+++ b/api/v1/dogu_types.go
@@ -234,8 +234,8 @@ func (d *Dogu) changeRequeuePhase(ctx context.Context, client client.Client, pha
 	return d.Update(ctx, client)
 }
 
-// ChangeRequeuePhaseWithRetry refreshes the dogu resource and tries to set the requeue phase. If a conflict error occurs
-// this method will retry the operation.
+// ChangeRequeuePhaseWithRetry refreshes the dogu resource and tries to set the requeue phase. 
+// If a conflict error occurs this method will retry the operation.
 func (d *Dogu) ChangeRequeuePhaseWithRetry(ctx context.Context, client client.Client, phase string) error {
 	return retry.OnConflict(func() error {
 		err := d.refreshDoguValue(ctx, client)
@@ -264,8 +264,8 @@ func (d *Dogu) changeState(ctx context.Context, client client.Client, newStatus 
 	return d.Update(ctx, client)
 }
 
-// ChangeStateWithRetry refreshes the dogu resource and tries to set the state. If a conflict error occurs
-// this method will retry the operation.
+// ChangeStateWithRetry refreshes the dogu resource and tries to set the state.
+// If a conflict error occurs this method will retry the operation.
 func (d *Dogu) ChangeStateWithRetry(ctx context.Context, client client.Client, newStatus string) error {
 	return retry.OnConflict(func() error {
 		err := d.refreshDoguValue(ctx, client)

--- a/api/v1/dogu_types.go
+++ b/api/v1/dogu_types.go
@@ -228,8 +228,8 @@ func (d *Dogu) Update(ctx context.Context, client client.Client) error {
 	return nil
 }
 
-// ChangeRequeuePhase changes the requeue phase of this dogu resource and applies it to the cluster state.
-func (d *Dogu) ChangeRequeuePhase(ctx context.Context, client client.Client, phase string) error {
+// changeRequeuePhase changes the requeue phase of this dogu resource and applies it to the cluster state.
+func (d *Dogu) changeRequeuePhase(ctx context.Context, client client.Client, phase string) error {
 	d.Status.RequeuePhase = phase
 	return d.Update(ctx, client)
 }
@@ -243,7 +243,7 @@ func (d *Dogu) ChangeRequeuePhaseWithRetry(ctx context.Context, client client.Cl
 			return err
 		}
 
-		return d.ChangeRequeuePhase(ctx, client, phase)
+		return d.changeRequeuePhase(ctx, client, phase)
 	})
 }
 
@@ -258,8 +258,8 @@ func (d *Dogu) refreshDoguValue(ctx context.Context, client client.Client) error
 	return nil
 }
 
-// ChangeState changes the state of this dogu resource and applies it to the cluster state.
-func (d *Dogu) ChangeState(ctx context.Context, client client.Client, newStatus string) error {
+// changeState changes the state of this dogu resource and applies it to the cluster state.
+func (d *Dogu) changeState(ctx context.Context, client client.Client, newStatus string) error {
 	d.Status.Status = newStatus
 	return d.Update(ctx, client)
 }
@@ -273,7 +273,7 @@ func (d *Dogu) ChangeStateWithRetry(ctx context.Context, client client.Client, n
 			return err
 		}
 
-		return d.ChangeState(ctx, client, newStatus)
+		return d.changeState(ctx, client, newStatus)
 	})
 }
 

--- a/api/v1/dogu_types.go
+++ b/api/v1/dogu_types.go
@@ -219,10 +219,13 @@ func (d *Dogu) ChangeRequeuePhase(ctx context.Context, client client.Client, pha
 // this method will retry the operation.
 func (d *Dogu) ChangeRequeuePhaseWithRetry(ctx context.Context, client client.Client, phase string) error {
 	return retry.OnConflict(func() error {
-		err := client.Get(ctx, d.GetObjectKey(), d)
+		freshDogu := &Dogu{}
+		err := client.Get(ctx, d.GetObjectKey(), freshDogu)
 		if err != nil {
 			return err
 		}
+
+		*d = *freshDogu
 
 		return d.ChangeRequeuePhase(ctx, client, phase)
 	})

--- a/api/v1/dogu_types_test.go
+++ b/api/v1/dogu_types_test.go
@@ -405,7 +405,7 @@ func TestDogu_ChangeRequeuePhaseWithRetry(t *testing.T) {
 	})
 }
 
-func TestDogu_ChangeRequeuePhaseWithRetry1(t *testing.T) {
+func TestDogu_ChangeStateWithRetry(t *testing.T) {
 	t.Run("success on conflict", func(t *testing.T) {
 		// given
 		resourceVersion := "1"

--- a/api/v1/dogu_types_test.go
+++ b/api/v1/dogu_types_test.go
@@ -103,38 +103,6 @@ func TestDogu_GetSecretObjectKey(t *testing.T) {
 	assert.Equal(t, "testnamespace", key.Namespace)
 }
 
-func Test_Dogu_ChangeState(t *testing.T) {
-	ctx := context.TODO()
-
-	t.Run("should set the dogu resource's status to upgrade", func(t *testing.T) {
-		sut := &v1.Dogu{}
-		mockClient := extMocks.NewK8sClient(t)
-		statusMock := extMocks.NewK8sSubResourceWriter(t)
-		mockClient.EXPECT().Status().Return(statusMock)
-		statusMock.On("Update", ctx, sut).Return(nil)
-
-		// when
-		err := sut.ChangeState(ctx, mockClient, v1.DoguStatusUpgrading)
-
-		// then
-		require.NoError(t, err)
-		assert.Equal(t, v1.DoguStatusUpgrading, sut.Status.Status)
-	})
-	t.Run("should fail on client error", func(t *testing.T) {
-		sut := &v1.Dogu{}
-		mockClient := extMocks.NewK8sClient(t)
-		statusMock := extMocks.NewK8sSubResourceWriter(t)
-		mockClient.EXPECT().Status().Return(statusMock)
-		statusMock.On("Update", ctx, sut).Return(assert.AnError)
-
-		// when
-		err := sut.ChangeState(ctx, mockClient, v1.DoguStatusUpgrading)
-
-		// then
-		require.ErrorIs(t, err, assert.AnError)
-	})
-}
-
 func TestDogu_GetObjectKey(t *testing.T) {
 	actual := testDogu.GetObjectKey()
 

--- a/controllers/doguDeleteManager.go
+++ b/controllers/doguDeleteManager.go
@@ -46,8 +46,7 @@ func NewDoguDeleteManager(client client.Client, _ *config.OperatorConfig, cesReg
 // Delete deletes the given dogu along with all those Kubernetes resources that the dogu operator initially created.
 func (m *doguDeleteManager) Delete(ctx context.Context, doguResource *k8sv1.Dogu) error {
 	logger := log.FromContext(ctx)
-	doguResource.Status = k8sv1.DoguStatus{Status: k8sv1.DoguStatusDeleting}
-	err := doguResource.Update(ctx, m.client)
+	err := doguResource.ChangeStateWithRetry(ctx, m.client, k8sv1.DoguStatusDeleting)
 	if err != nil {
 		return err
 	}

--- a/controllers/doguDeleteManager_test.go
+++ b/controllers/doguDeleteManager_test.go
@@ -103,7 +103,7 @@ func Test_doguDeleteManager_Delete(t *testing.T) {
 		assert.Empty(t, deletedDogu.Finalizers)
 	})
 
-	t.Run("failed to update dogu status", func(t *testing.T) {
+	t.Run("failed to update dogu status because the dogu cr is not found", func(t *testing.T) {
 		// given
 		managerWithMocks := getDoguDeleteManagerWithMocks(t)
 
@@ -112,7 +112,6 @@ func Test_doguDeleteManager_Delete(t *testing.T) {
 
 		// then
 		require.Error(t, err)
-		assert.ErrorContains(t, err, "failed to update dogu status")
 	})
 
 	t.Run("failure during fetching local dogu should not interrupt the delete routine", func(t *testing.T) {

--- a/controllers/doguUpgradeManager.go
+++ b/controllers/doguUpgradeManager.go
@@ -51,7 +51,7 @@ type doguUpgradeManager struct {
 }
 
 func (dum *doguUpgradeManager) Upgrade(ctx context.Context, doguResource *k8sv1.Dogu) error {
-	err := doguResource.ChangeState(ctx, dum.client, k8sv1.DoguStatusUpgrading)
+	err := doguResource.ChangeStateWithRetry(ctx, dum.client, k8sv1.DoguStatusUpgrading)
 	if err != nil {
 		return err
 	}
@@ -77,7 +77,7 @@ func (dum *doguUpgradeManager) Upgrade(ctx context.Context, doguResource *k8sv1.
 	}
 	// note: there won't exist a purgeOldContainerImage step: that is the subject of Kubernetes's cluster configuration
 
-	err = doguResource.ChangeState(ctx, dum.client, k8sv1.DoguStatusInstalled)
+	err = doguResource.ChangeStateWithRetry(ctx, dum.client, k8sv1.DoguStatusInstalled)
 	if err != nil {
 		return err
 	}

--- a/controllers/doguVolumeManager.go
+++ b/controllers/doguVolumeManager.go
@@ -90,7 +90,7 @@ func createAsyncSteps(executor cloudogu.AsyncExecutor, client client.Client, rec
 
 // SetDoguDataVolumeSize sets the quantity from the doguResource in the dogu data PVC.
 func (d *doguVolumeManager) SetDoguDataVolumeSize(ctx context.Context, doguResource *k8sv1.Dogu) error {
-	err := doguResource.ChangeState(ctx, d.client, k8sv1.DoguStatusPVCResizing)
+	err := doguResource.ChangeStateWithRetry(ctx, d.client, k8sv1.DoguStatusPVCResizing)
 	if err != nil {
 		return err
 	}
@@ -100,7 +100,7 @@ func (d *doguVolumeManager) SetDoguDataVolumeSize(ctx context.Context, doguResou
 		return err
 	}
 
-	return doguResource.ChangeState(ctx, d.client, k8sv1.DoguStatusInstalled)
+	return doguResource.ChangeStateWithRetry(ctx, d.client, k8sv1.DoguStatusInstalled)
 }
 
 type editPVCStep struct {
@@ -188,8 +188,7 @@ func (s *scaleUpStep) Execute(ctx context.Context, dogu *k8sv1.Dogu) (string, er
 		return s.GetStartCondition(), err
 	}
 
-	dogu.Status.RequeuePhase = ""
-	err = dogu.Update(ctx, s.client)
+	err = dogu.ChangeRequeuePhaseWithRetry(ctx, s.client, "")
 	if err != nil {
 		return "", err
 	}

--- a/controllers/dogu_controller.go
+++ b/controllers/dogu_controller.go
@@ -380,8 +380,8 @@ func (r *doguReconciler) performOperation(ctx context.Context, doguResource *k8s
 	}
 
 	result, handleErr := r.doguRequeueHandler.Handle(ctx, contextMessageOnError, doguResource, operationError,
-		func(dogu *k8sv1.Dogu) {
-			doguResource.Status.Status = requeueDoguStatus
+		func(dogu *k8sv1.Dogu) error {
+			return doguResource.ChangeStateWithRetry(ctx, r.client, requeueDoguStatus)
 		})
 	if handleErr != nil {
 		r.recorder.Eventf(doguResource, v1.EventTypeWarning, ErrorOnRequeueEventReason,

--- a/controllers/dogu_requeue_handler.go
+++ b/controllers/dogu_requeue_handler.go
@@ -80,8 +80,7 @@ func (d *doguRequeueHandler) Handle(ctx context.Context, contextMessage string, 
 		onRequeue(doguResource)
 	}
 
-	doguResource.Status.RequeuePhase = getRequeuePhase(originalErr)
-	updateError := doguResource.Update(ctx, d.client)
+	updateError := doguResource.ChangeRequeuePhaseWithRetry(ctx, d.client, getRequeuePhase(originalErr))
 	if updateError != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to update dogu status: %w", updateError)
 	}

--- a/controllers/dogu_requeue_handler.go
+++ b/controllers/dogu_requeue_handler.go
@@ -70,14 +70,20 @@ func NewDoguRequeueHandler(client client.Client, recorder record.EventRecorder, 
 }
 
 // Handle takes an error and handles the requeue process for the current dogu operation.
-func (d *doguRequeueHandler) Handle(ctx context.Context, contextMessage string, doguResource *k8sv1.Dogu, originalErr error, onRequeue func(dogu *k8sv1.Dogu)) (ctrl.Result, error) {
+func (d *doguRequeueHandler) Handle(ctx context.Context, contextMessage string, doguResource *k8sv1.Dogu, originalErr error, onRequeue func(dogu *k8sv1.Dogu) error) (ctrl.Result, error) {
 	if !shouldRequeue(originalErr) {
 		return ctrl.Result{}, nil
 	}
 
-	requeueTime := getRequeueTime(doguResource, originalErr)
+	requeueTime, timeErr := getRequeueTime(ctx, doguResource, d.client, originalErr)
+	if timeErr != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to get requeue time: %w", timeErr)
+	}
 	if onRequeue != nil {
-		onRequeue(doguResource)
+		onRequeueErr := onRequeue(doguResource)
+		if onRequeueErr != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to call onRequeue handler: %w", onRequeueErr)
+		}
 	}
 
 	updateError := doguResource.ChangeRequeuePhaseWithRetry(ctx, d.client, getRequeuePhase(originalErr))
@@ -106,13 +112,18 @@ func getRequeuePhase(err error) string {
 	return ""
 }
 
-func getRequeueTime(dogu *k8sv1.Dogu, err error) time.Duration {
+func getRequeueTime(ctx context.Context, dogu *k8sv1.Dogu, client client.Client, err error) (time.Duration, error) {
 	var errorWithTime requeuableErrorWithTime
 	if errors.As(err, &errorWithTime) {
-		return errorWithTime.GetRequeueTime()
+		return errorWithTime.GetRequeueTime(), nil
 	}
 
-	return dogu.Status.NextRequeue()
+	requeueTime, timeErr := dogu.NextRequeueWithRetry(ctx, client)
+	if timeErr != nil {
+		return 0, timeErr
+	}
+
+	return requeueTime, nil
 }
 
 func shouldRequeue(err error) bool {

--- a/controllers/dogu_requeue_handler_test.go
+++ b/controllers/dogu_requeue_handler_test.go
@@ -54,7 +54,7 @@ func TestDoguRequeueHandler_Handle(t *testing.T) {
 			recorder:       eventRecorder,
 		}
 
-		onRequeue := func(doguResource *k8sv1.Dogu) { doguResource.Labels["test"] = "true" }
+		onRequeue := func(doguResource *k8sv1.Dogu) error { doguResource.Labels["test"] = "true"; return nil }
 
 		// when
 		result, err := handler.Handle(context.Background(), "my context", doguResource, nil, onRequeue)
@@ -86,7 +86,7 @@ func TestDoguRequeueHandler_Handle(t *testing.T) {
 			recorder:       eventRecorder,
 		}
 
-		onRequeue := func(doguResource *k8sv1.Dogu) { doguResource.Labels["test"] = "true" }
+		onRequeue := func(doguResource *k8sv1.Dogu) error { doguResource.Labels["test"] = "true"; return nil }
 
 		// when
 		result, err := handler.Handle(context.Background(), "my context", doguResource, assert.AnError, onRequeue)
@@ -130,8 +130,9 @@ func TestDoguRequeueHandler_Handle(t *testing.T) {
 		myError := myRequeueableError{}
 
 		requeueCalled := false
-		onRequeue := func(doguResource *k8sv1.Dogu) {
+		onRequeue := func(doguResource *k8sv1.Dogu) error {
 			requeueCalled = true
+			return nil
 		}
 
 		// when
@@ -185,8 +186,9 @@ func TestDoguRequeueHandler_Handle(t *testing.T) {
 		myMultipleErrors = errors.Join(myMultipleErrors, myError, myError2)
 
 		requeueCalled := false
-		onRequeue := func(doguResource *k8sv1.Dogu) {
+		onRequeue := func(doguResource *k8sv1.Dogu) error {
 			requeueCalled = true
+			return nil
 		}
 
 		// when

--- a/internal/cloudogu/controllers.go
+++ b/internal/cloudogu/controllers.go
@@ -56,5 +56,5 @@ type DoguManager interface {
 // RequeueHandler abstracts the process to decide whether a requeue process should be done based on received errors.
 type RequeueHandler interface {
 	// Handle takes an error and handles the requeue process for the current dogu operation.
-	Handle(ctx context.Context, contextMessage string, doguResource *v1.Dogu, err error, onRequeue func(dogu *v1.Dogu)) (result ctrl.Result, requeueErr error)
+	Handle(ctx context.Context, contextMessage string, doguResource *v1.Dogu, err error, onRequeue func(dogu *v1.Dogu) error) (result ctrl.Result, requeueErr error)
 }

--- a/internal/cloudogu/mocks/RequeueHandler.go
+++ b/internal/cloudogu/mocks/RequeueHandler.go
@@ -25,21 +25,21 @@ func (_m *RequeueHandler) EXPECT() *RequeueHandler_Expecter {
 }
 
 // Handle provides a mock function with given fields: ctx, contextMessage, doguResource, err, onRequeue
-func (_m *RequeueHandler) Handle(ctx context.Context, contextMessage string, doguResource *v1.Dogu, err error, onRequeue func(*v1.Dogu)) (reconcile.Result, error) {
+func (_m *RequeueHandler) Handle(ctx context.Context, contextMessage string, doguResource *v1.Dogu, err error, onRequeue func(*v1.Dogu) error) (reconcile.Result, error) {
 	ret := _m.Called(ctx, contextMessage, doguResource, err, onRequeue)
 
 	var r0 reconcile.Result
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, *v1.Dogu, error, func(*v1.Dogu)) (reconcile.Result, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string, *v1.Dogu, error, func(*v1.Dogu) error) (reconcile.Result, error)); ok {
 		return rf(ctx, contextMessage, doguResource, err, onRequeue)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, *v1.Dogu, error, func(*v1.Dogu)) reconcile.Result); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string, *v1.Dogu, error, func(*v1.Dogu) error) reconcile.Result); ok {
 		r0 = rf(ctx, contextMessage, doguResource, err, onRequeue)
 	} else {
 		r0 = ret.Get(0).(reconcile.Result)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, *v1.Dogu, error, func(*v1.Dogu)) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, string, *v1.Dogu, error, func(*v1.Dogu) error) error); ok {
 		r1 = rf(ctx, contextMessage, doguResource, err, onRequeue)
 	} else {
 		r1 = ret.Error(1)
@@ -58,14 +58,14 @@ type RequeueHandler_Handle_Call struct {
 //   - contextMessage string
 //   - doguResource *v1.Dogu
 //   - err error
-//   - onRequeue func(*v1.Dogu)
+//   - onRequeue func(*v1.Dogu) error
 func (_e *RequeueHandler_Expecter) Handle(ctx interface{}, contextMessage interface{}, doguResource interface{}, err interface{}, onRequeue interface{}) *RequeueHandler_Handle_Call {
 	return &RequeueHandler_Handle_Call{Call: _e.mock.On("Handle", ctx, contextMessage, doguResource, err, onRequeue)}
 }
 
-func (_c *RequeueHandler_Handle_Call) Run(run func(ctx context.Context, contextMessage string, doguResource *v1.Dogu, err error, onRequeue func(*v1.Dogu))) *RequeueHandler_Handle_Call {
+func (_c *RequeueHandler_Handle_Call) Run(run func(ctx context.Context, contextMessage string, doguResource *v1.Dogu, err error, onRequeue func(*v1.Dogu) error)) *RequeueHandler_Handle_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(*v1.Dogu), args[3].(error), args[4].(func(*v1.Dogu)))
+		run(args[0].(context.Context), args[1].(string), args[2].(*v1.Dogu), args[3].(error), args[4].(func(*v1.Dogu) error))
 	})
 	return _c
 }
@@ -75,7 +75,7 @@ func (_c *RequeueHandler_Handle_Call) Return(result reconcile.Result, requeueErr
 	return _c
 }
 
-func (_c *RequeueHandler_Handle_Call) RunAndReturn(run func(context.Context, string, *v1.Dogu, error, func(*v1.Dogu)) (reconcile.Result, error)) *RequeueHandler_Handle_Call {
+func (_c *RequeueHandler_Handle_Call) RunAndReturn(run func(context.Context, string, *v1.Dogu, error, func(*v1.Dogu) error) (reconcile.Result, error)) *RequeueHandler_Handle_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
With the health reconciler two components update the status of the dogu cr. We need to stabilize the update process with retries because dogu upgrade can cause conflict errors.

Resolves #156 