### PR TITLE
AdditionalMounts: Use user and group id from dogu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- [#248] Use correct user and group ids for the `additionalMounts` Init-Container.
 
 ## [v3.8.0] - 2025-06-05
 ### Added

--- a/controllers/doguAdditionalMountManager.go
+++ b/controllers/doguAdditionalMountManager.go
@@ -110,7 +110,7 @@ func (m *doguAdditionalMountManager) createAdditionalMountInitContainer(ctx cont
 		return nil, fmt.Errorf("failed to generate requirements for dogu %s: %w", doguResource.Name, err)
 	}
 
-	container, err := m.resourceGenerator.BuildAdditionalMountInitContainer(dogu, doguResource, m.image, requirements)
+	container, err := m.resourceGenerator.BuildAdditionalMountInitContainer(ctx, dogu, doguResource, m.image, requirements)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate dogu additional mounts init container while diff calculation: %w", err)
 	}

--- a/controllers/doguAdditionalMountManager_test.go
+++ b/controllers/doguAdditionalMountManager_test.go
@@ -166,7 +166,7 @@ func Test_doguAdditionalMountsManager_AdditionalMountsChanged(t *testing.T) {
 				},
 				resourceGenerator: func() additionalMountsInitContainerGenerator {
 					mock := newMockAdditionalMountsInitContainerGenerator(t)
-					mock.EXPECT().BuildAdditionalMountInitContainer(nginxDogu, nginxDoguResourceWithAdditionalMounts, "", corev1.ResourceRequirements{}).Return(expectedInitContainerWithAdditionalMounts, nil)
+					mock.EXPECT().BuildAdditionalMountInitContainer(testCtx, nginxDogu, nginxDoguResourceWithAdditionalMounts, "", corev1.ResourceRequirements{}).Return(expectedInitContainerWithAdditionalMounts, nil)
 					return mock
 				},
 				requirementsGenerator: func() requirementsGenerator {
@@ -213,7 +213,7 @@ func Test_doguAdditionalMountsManager_AdditionalMountsChanged(t *testing.T) {
 				},
 				resourceGenerator: func() additionalMountsInitContainerGenerator {
 					mock := newMockAdditionalMountsInitContainerGenerator(t)
-					mock.EXPECT().BuildAdditionalMountInitContainer(nginxDogu, nginxDoguResourceWithAdditionalMounts, "", corev1.ResourceRequirements{}).Return(expectedInitContainerWithAdditionalMounts, nil)
+					mock.EXPECT().BuildAdditionalMountInitContainer(testCtx, nginxDogu, nginxDoguResourceWithAdditionalMounts, "", corev1.ResourceRequirements{}).Return(expectedInitContainerWithAdditionalMounts, nil)
 					return mock
 				},
 				requirementsGenerator: func() requirementsGenerator {
@@ -372,7 +372,7 @@ func Test_doguAdditionalMountsManager_createDataMountInitContainer(t *testing.T)
 				},
 				resourceGenerator: func() additionalMountsInitContainerGenerator {
 					mock := newMockAdditionalMountsInitContainerGenerator(t)
-					mock.EXPECT().BuildAdditionalMountInitContainer(nginxDogu, nginxDoguResource, "", corev1.ResourceRequirements{}).Return(nil, assert.AnError)
+					mock.EXPECT().BuildAdditionalMountInitContainer(testCtx, nginxDogu, nginxDoguResource, "", corev1.ResourceRequirements{}).Return(nil, assert.AnError)
 					return mock
 				},
 				requirementsGenerator: func() requirementsGenerator {
@@ -557,7 +557,7 @@ func Test_doguAdditionalMountsManager_UpdateAdditionalMounts(t *testing.T) {
 				},
 				resourceGenerator: func() additionalMountsInitContainerGenerator {
 					mock := newMockAdditionalMountsInitContainerGenerator(t)
-					mock.EXPECT().BuildAdditionalMountInitContainer(nginxDogu, nginxDoguResourceWithAdditionalMounts, "", corev1.ResourceRequirements{}).Return(updatedInitContainer, nil)
+					mock.EXPECT().BuildAdditionalMountInitContainer(testCtx, nginxDogu, nginxDoguResourceWithAdditionalMounts, "", corev1.ResourceRequirements{}).Return(updatedInitContainer, nil)
 					return mock
 				},
 				requirementsGenerator: func() requirementsGenerator {
@@ -599,7 +599,7 @@ func Test_doguAdditionalMountsManager_UpdateAdditionalMounts(t *testing.T) {
 				},
 				resourceGenerator: func() additionalMountsInitContainerGenerator {
 					mock := newMockAdditionalMountsInitContainerGenerator(t)
-					mock.EXPECT().BuildAdditionalMountInitContainer(nginxDogu, nginxDoguResourceWithAdditionalMounts, "", corev1.ResourceRequirements{}).Return(updatedInitContainer, nil)
+					mock.EXPECT().BuildAdditionalMountInitContainer(testCtx, nginxDogu, nginxDoguResourceWithAdditionalMounts, "", corev1.ResourceRequirements{}).Return(updatedInitContainer, nil)
 					return mock
 				},
 				requirementsGenerator: func() requirementsGenerator {
@@ -639,7 +639,7 @@ func Test_doguAdditionalMountsManager_UpdateAdditionalMounts(t *testing.T) {
 				},
 				resourceGenerator: func() additionalMountsInitContainerGenerator {
 					mock := newMockAdditionalMountsInitContainerGenerator(t)
-					mock.EXPECT().BuildAdditionalMountInitContainer(nginxDogu, nginxDoguResourceWithAdditionalMounts, "", corev1.ResourceRequirements{}).Return(updatedInitContainer, nil)
+					mock.EXPECT().BuildAdditionalMountInitContainer(testCtx, nginxDogu, nginxDoguResourceWithAdditionalMounts, "", corev1.ResourceRequirements{}).Return(updatedInitContainer, nil)
 					return mock
 				},
 				requirementsGenerator: func() requirementsGenerator {

--- a/controllers/interfaces.go
+++ b/controllers/interfaces.go
@@ -78,7 +78,7 @@ type additionalMountsManager interface {
 }
 
 type additionalMountsInitContainerGenerator interface {
-	BuildAdditionalMountInitContainer(dogu *cesappcore.Dogu, doguResource *v2.Dogu, image string, requirements coreV1.ResourceRequirements) (*coreV1.Container, error)
+	BuildAdditionalMountInitContainer(ctx context.Context, dogu *cesappcore.Dogu, doguResource *v2.Dogu, image string, requirements coreV1.ResourceRequirements) (*coreV1.Container, error)
 }
 
 type startStopManager interface {

--- a/controllers/mock_additionalMountsInitContainerGenerator_test.go
+++ b/controllers/mock_additionalMountsInitContainerGenerator_test.go
@@ -3,6 +3,8 @@
 package controllers
 
 import (
+	context "context"
+
 	core "github.com/cloudogu/cesapp-lib/core"
 	mock "github.com/stretchr/testify/mock"
 
@@ -24,9 +26,9 @@ func (_m *mockAdditionalMountsInitContainerGenerator) EXPECT() *mockAdditionalMo
 	return &mockAdditionalMountsInitContainerGenerator_Expecter{mock: &_m.Mock}
 }
 
-// BuildAdditionalMountInitContainer provides a mock function with given fields: dogu, doguResource, image, requirements
-func (_m *mockAdditionalMountsInitContainerGenerator) BuildAdditionalMountInitContainer(dogu *core.Dogu, doguResource *v2.Dogu, image string, requirements v1.ResourceRequirements) (*v1.Container, error) {
-	ret := _m.Called(dogu, doguResource, image, requirements)
+// BuildAdditionalMountInitContainer provides a mock function with given fields: ctx, dogu, doguResource, image, requirements
+func (_m *mockAdditionalMountsInitContainerGenerator) BuildAdditionalMountInitContainer(ctx context.Context, dogu *core.Dogu, doguResource *v2.Dogu, image string, requirements v1.ResourceRequirements) (*v1.Container, error) {
+	ret := _m.Called(ctx, dogu, doguResource, image, requirements)
 
 	if len(ret) == 0 {
 		panic("no return value specified for BuildAdditionalMountInitContainer")
@@ -34,19 +36,19 @@ func (_m *mockAdditionalMountsInitContainerGenerator) BuildAdditionalMountInitCo
 
 	var r0 *v1.Container
 	var r1 error
-	if rf, ok := ret.Get(0).(func(*core.Dogu, *v2.Dogu, string, v1.ResourceRequirements) (*v1.Container, error)); ok {
-		return rf(dogu, doguResource, image, requirements)
+	if rf, ok := ret.Get(0).(func(context.Context, *core.Dogu, *v2.Dogu, string, v1.ResourceRequirements) (*v1.Container, error)); ok {
+		return rf(ctx, dogu, doguResource, image, requirements)
 	}
-	if rf, ok := ret.Get(0).(func(*core.Dogu, *v2.Dogu, string, v1.ResourceRequirements) *v1.Container); ok {
-		r0 = rf(dogu, doguResource, image, requirements)
+	if rf, ok := ret.Get(0).(func(context.Context, *core.Dogu, *v2.Dogu, string, v1.ResourceRequirements) *v1.Container); ok {
+		r0 = rf(ctx, dogu, doguResource, image, requirements)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*v1.Container)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(*core.Dogu, *v2.Dogu, string, v1.ResourceRequirements) error); ok {
-		r1 = rf(dogu, doguResource, image, requirements)
+	if rf, ok := ret.Get(1).(func(context.Context, *core.Dogu, *v2.Dogu, string, v1.ResourceRequirements) error); ok {
+		r1 = rf(ctx, dogu, doguResource, image, requirements)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -60,17 +62,18 @@ type mockAdditionalMountsInitContainerGenerator_BuildAdditionalMountInitContaine
 }
 
 // BuildAdditionalMountInitContainer is a helper method to define mock.On call
+//   - ctx context.Context
 //   - dogu *core.Dogu
 //   - doguResource *v2.Dogu
 //   - image string
 //   - requirements v1.ResourceRequirements
-func (_e *mockAdditionalMountsInitContainerGenerator_Expecter) BuildAdditionalMountInitContainer(dogu interface{}, doguResource interface{}, image interface{}, requirements interface{}) *mockAdditionalMountsInitContainerGenerator_BuildAdditionalMountInitContainer_Call {
-	return &mockAdditionalMountsInitContainerGenerator_BuildAdditionalMountInitContainer_Call{Call: _e.mock.On("BuildAdditionalMountInitContainer", dogu, doguResource, image, requirements)}
+func (_e *mockAdditionalMountsInitContainerGenerator_Expecter) BuildAdditionalMountInitContainer(ctx interface{}, dogu interface{}, doguResource interface{}, image interface{}, requirements interface{}) *mockAdditionalMountsInitContainerGenerator_BuildAdditionalMountInitContainer_Call {
+	return &mockAdditionalMountsInitContainerGenerator_BuildAdditionalMountInitContainer_Call{Call: _e.mock.On("BuildAdditionalMountInitContainer", ctx, dogu, doguResource, image, requirements)}
 }
 
-func (_c *mockAdditionalMountsInitContainerGenerator_BuildAdditionalMountInitContainer_Call) Run(run func(dogu *core.Dogu, doguResource *v2.Dogu, image string, requirements v1.ResourceRequirements)) *mockAdditionalMountsInitContainerGenerator_BuildAdditionalMountInitContainer_Call {
+func (_c *mockAdditionalMountsInitContainerGenerator_BuildAdditionalMountInitContainer_Call) Run(run func(ctx context.Context, dogu *core.Dogu, doguResource *v2.Dogu, image string, requirements v1.ResourceRequirements)) *mockAdditionalMountsInitContainerGenerator_BuildAdditionalMountInitContainer_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(*core.Dogu), args[1].(*v2.Dogu), args[2].(string), args[3].(v1.ResourceRequirements))
+		run(args[0].(context.Context), args[1].(*core.Dogu), args[2].(*v2.Dogu), args[3].(string), args[4].(v1.ResourceRequirements))
 	})
 	return _c
 }
@@ -80,7 +83,7 @@ func (_c *mockAdditionalMountsInitContainerGenerator_BuildAdditionalMountInitCon
 	return _c
 }
 
-func (_c *mockAdditionalMountsInitContainerGenerator_BuildAdditionalMountInitContainer_Call) RunAndReturn(run func(*core.Dogu, *v2.Dogu, string, v1.ResourceRequirements) (*v1.Container, error)) *mockAdditionalMountsInitContainerGenerator_BuildAdditionalMountInitContainer_Call {
+func (_c *mockAdditionalMountsInitContainerGenerator_BuildAdditionalMountInitContainer_Call) RunAndReturn(run func(context.Context, *core.Dogu, *v2.Dogu, string, v1.ResourceRequirements) (*v1.Container, error)) *mockAdditionalMountsInitContainerGenerator_BuildAdditionalMountInitContainer_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/controllers/resource/resource_generator_test.go
+++ b/controllers/resource/resource_generator_test.go
@@ -585,7 +585,7 @@ func Test_BuildAdditionalMountInitContainer(t *testing.T) {
 		sut := &resourceGenerator{}
 
 		// when
-		container, err := sut.BuildAdditionalMountInitContainer(dogu, doguResource, testInitContainerImage, resources)
+		container, err := sut.BuildAdditionalMountInitContainer(testCtx, dogu, doguResource, testInitContainerImage, resources)
 
 		// then
 		require.NoError(t, err)
@@ -629,7 +629,7 @@ func Test_BuildAdditionalMountInitContainer(t *testing.T) {
 		sut := &resourceGenerator{}
 
 		// when
-		container, err := sut.BuildAdditionalMountInitContainer(dogu, doguResource, expectedContainerImage, resources)
+		container, err := sut.BuildAdditionalMountInitContainer(testCtx, dogu, doguResource, expectedContainerImage, resources)
 
 		// then
 		require.NoError(t, err)
@@ -669,7 +669,7 @@ func Test_BuildAdditionalMountInitContainer(t *testing.T) {
 		sut := &resourceGenerator{}
 
 		// when
-		container, err := sut.BuildAdditionalMountInitContainer(dogu, doguResource, expectedContainerImage, resources)
+		container, err := sut.BuildAdditionalMountInitContainer(testCtx, dogu, doguResource, expectedContainerImage, resources)
 
 		// then
 		require.NoError(t, err)
@@ -721,7 +721,7 @@ func Test_BuildAdditionalMountInitContainer(t *testing.T) {
 		sut := &resourceGenerator{}
 
 		// when
-		container, err := sut.BuildAdditionalMountInitContainer(dogu, doguResource, testInitContainerImage, v1.ResourceRequirements{})
+		container, err := sut.BuildAdditionalMountInitContainer(testCtx, dogu, doguResource, testInitContainerImage, v1.ResourceRequirements{})
 
 		// then
 		require.NoError(t, err)
@@ -770,7 +770,7 @@ func Test_BuildAdditionalMountInitContainer(t *testing.T) {
 		sut := &resourceGenerator{}
 
 		// when
-		container, err := sut.BuildAdditionalMountInitContainer(dogu, doguResource, testInitContainerImage, v1.ResourceRequirements{})
+		container, err := sut.BuildAdditionalMountInitContainer(testCtx, dogu, doguResource, testInitContainerImage, v1.ResourceRequirements{})
 
 		// then
 		require.NoError(t, err)
@@ -801,7 +801,7 @@ func Test_BuildAdditionalMountInitContainer(t *testing.T) {
 		sut := &resourceGenerator{}
 
 		// when
-		container, err := sut.BuildAdditionalMountInitContainer(dogu, doguResource, testInitContainerImage, v1.ResourceRequirements{})
+		container, err := sut.BuildAdditionalMountInitContainer(testCtx, dogu, doguResource, testInitContainerImage, v1.ResourceRequirements{})
 
 		// then
 		require.NoError(t, err)
@@ -821,7 +821,7 @@ func Test_BuildAdditionalMountInitContainer(t *testing.T) {
 		sut := &resourceGenerator{}
 
 		// when
-		_, err := sut.BuildAdditionalMountInitContainer(dogu, doguResource, testInitContainerImage, v1.ResourceRequirements{})
+		_, err := sut.BuildAdditionalMountInitContainer(testCtx, dogu, doguResource, testInitContainerImage, v1.ResourceRequirements{})
 
 		// then
 		require.Error(t, err)
@@ -843,7 +843,7 @@ func Test_BuildAdditionalMountInitContainer(t *testing.T) {
 		sut := &resourceGenerator{}
 
 		// when
-		container, err := sut.BuildAdditionalMountInitContainer(dogu, doguResource, testInitContainerImage, v1.ResourceRequirements{})
+		container, err := sut.BuildAdditionalMountInitContainer(testCtx, dogu, doguResource, testInitContainerImage, v1.ResourceRequirements{})
 
 		// then
 		require.NoError(t, err)
@@ -865,7 +865,7 @@ func Test_BuildAdditionalMountInitContainer(t *testing.T) {
 		sut := &resourceGenerator{}
 
 		// when
-		container, err := sut.BuildAdditionalMountInitContainer(dogu, doguResource, testInitContainerImage, v1.ResourceRequirements{})
+		container, err := sut.BuildAdditionalMountInitContainer(testCtx, dogu, doguResource, testInitContainerImage, v1.ResourceRequirements{})
 
 		// then
 		require.NoError(t, err)

--- a/controllers/resource/testdata/ldap_expectedDeployment.yaml
+++ b/controllers/resource/testdata/ldap_expectedDeployment.yaml
@@ -64,6 +64,8 @@ spec:
           name: dogu-additional-mounts-init
           resources: { }
           securityContext:
+            RunAsUser: 100
+            RunAsGroup: 101
             appArmorProfile:
               type: Unconfined
             capabilities:

--- a/controllers/resource/testdata/ldap_expectedDeployment_Development.yaml
+++ b/controllers/resource/testdata/ldap_expectedDeployment_Development.yaml
@@ -63,6 +63,8 @@ spec:
           name: dogu-additional-mounts-init
           resources: { }
           securityContext:
+            RunAsUser: 100
+            RunAsGroup: 101
             appArmorProfile:
               type: Unconfined
             capabilities:

--- a/controllers/resource/testdata/ldap_expectedDeployment_ExporterSidecar.yaml
+++ b/controllers/resource/testdata/ldap_expectedDeployment_ExporterSidecar.yaml
@@ -63,6 +63,8 @@ spec:
           name: dogu-additional-mounts-init
           resources: { }
           securityContext:
+            RunAsUser: 100
+            RunAsGroup: 101
             appArmorProfile:
               type: Unconfined
             capabilities:

--- a/controllers/resource/testdata/ldap_expectedDeployment_SecurityContext.yaml
+++ b/controllers/resource/testdata/ldap_expectedDeployment_SecurityContext.yaml
@@ -63,6 +63,8 @@ spec:
           name: dogu-additional-mounts-init
           resources: { }
           securityContext:
+            RunAsUser: 100
+            RunAsGroup: 101
             appArmorProfile:
               type: Unconfined
             capabilities:

--- a/controllers/util/interfaces.go
+++ b/controllers/util/interfaces.go
@@ -27,7 +27,7 @@ type doguAdditionalMountsValidator interface {
 }
 
 type additionalMountsInitContainerGenerator interface {
-	BuildAdditionalMountInitContainer(dogu *cesappcore.Dogu, doguResource *k8sv2.Dogu, image string, requirements coreV1.ResourceRequirements) (*coreV1.Container, error)
+	BuildAdditionalMountInitContainer(ctx context.Context, dogu *cesappcore.Dogu, doguResource *k8sv2.Dogu, image string, requirements coreV1.ResourceRequirements) (*coreV1.Container, error)
 }
 
 // requirementsGenerator handles resource requirements (limits and requests) for dogu deployments.

--- a/controllers/util/mock_additionalMountsInitContainerGenerator_test.go
+++ b/controllers/util/mock_additionalMountsInitContainerGenerator_test.go
@@ -3,6 +3,8 @@
 package util
 
 import (
+	context "context"
+
 	core "github.com/cloudogu/cesapp-lib/core"
 	mock "github.com/stretchr/testify/mock"
 
@@ -24,9 +26,9 @@ func (_m *mockAdditionalMountsInitContainerGenerator) EXPECT() *mockAdditionalMo
 	return &mockAdditionalMountsInitContainerGenerator_Expecter{mock: &_m.Mock}
 }
 
-// BuildAdditionalMountInitContainer provides a mock function with given fields: dogu, doguResource, image, requirements
-func (_m *mockAdditionalMountsInitContainerGenerator) BuildAdditionalMountInitContainer(dogu *core.Dogu, doguResource *v2.Dogu, image string, requirements v1.ResourceRequirements) (*v1.Container, error) {
-	ret := _m.Called(dogu, doguResource, image, requirements)
+// BuildAdditionalMountInitContainer provides a mock function with given fields: ctx, dogu, doguResource, image, requirements
+func (_m *mockAdditionalMountsInitContainerGenerator) BuildAdditionalMountInitContainer(ctx context.Context, dogu *core.Dogu, doguResource *v2.Dogu, image string, requirements v1.ResourceRequirements) (*v1.Container, error) {
+	ret := _m.Called(ctx, dogu, doguResource, image, requirements)
 
 	if len(ret) == 0 {
 		panic("no return value specified for BuildAdditionalMountInitContainer")
@@ -34,19 +36,19 @@ func (_m *mockAdditionalMountsInitContainerGenerator) BuildAdditionalMountInitCo
 
 	var r0 *v1.Container
 	var r1 error
-	if rf, ok := ret.Get(0).(func(*core.Dogu, *v2.Dogu, string, v1.ResourceRequirements) (*v1.Container, error)); ok {
-		return rf(dogu, doguResource, image, requirements)
+	if rf, ok := ret.Get(0).(func(context.Context, *core.Dogu, *v2.Dogu, string, v1.ResourceRequirements) (*v1.Container, error)); ok {
+		return rf(ctx, dogu, doguResource, image, requirements)
 	}
-	if rf, ok := ret.Get(0).(func(*core.Dogu, *v2.Dogu, string, v1.ResourceRequirements) *v1.Container); ok {
-		r0 = rf(dogu, doguResource, image, requirements)
+	if rf, ok := ret.Get(0).(func(context.Context, *core.Dogu, *v2.Dogu, string, v1.ResourceRequirements) *v1.Container); ok {
+		r0 = rf(ctx, dogu, doguResource, image, requirements)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*v1.Container)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(*core.Dogu, *v2.Dogu, string, v1.ResourceRequirements) error); ok {
-		r1 = rf(dogu, doguResource, image, requirements)
+	if rf, ok := ret.Get(1).(func(context.Context, *core.Dogu, *v2.Dogu, string, v1.ResourceRequirements) error); ok {
+		r1 = rf(ctx, dogu, doguResource, image, requirements)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -60,17 +62,18 @@ type mockAdditionalMountsInitContainerGenerator_BuildAdditionalMountInitContaine
 }
 
 // BuildAdditionalMountInitContainer is a helper method to define mock.On call
+//   - ctx context.Context
 //   - dogu *core.Dogu
 //   - doguResource *v2.Dogu
 //   - image string
 //   - requirements v1.ResourceRequirements
-func (_e *mockAdditionalMountsInitContainerGenerator_Expecter) BuildAdditionalMountInitContainer(dogu interface{}, doguResource interface{}, image interface{}, requirements interface{}) *mockAdditionalMountsInitContainerGenerator_BuildAdditionalMountInitContainer_Call {
-	return &mockAdditionalMountsInitContainerGenerator_BuildAdditionalMountInitContainer_Call{Call: _e.mock.On("BuildAdditionalMountInitContainer", dogu, doguResource, image, requirements)}
+func (_e *mockAdditionalMountsInitContainerGenerator_Expecter) BuildAdditionalMountInitContainer(ctx interface{}, dogu interface{}, doguResource interface{}, image interface{}, requirements interface{}) *mockAdditionalMountsInitContainerGenerator_BuildAdditionalMountInitContainer_Call {
+	return &mockAdditionalMountsInitContainerGenerator_BuildAdditionalMountInitContainer_Call{Call: _e.mock.On("BuildAdditionalMountInitContainer", ctx, dogu, doguResource, image, requirements)}
 }
 
-func (_c *mockAdditionalMountsInitContainerGenerator_BuildAdditionalMountInitContainer_Call) Run(run func(dogu *core.Dogu, doguResource *v2.Dogu, image string, requirements v1.ResourceRequirements)) *mockAdditionalMountsInitContainerGenerator_BuildAdditionalMountInitContainer_Call {
+func (_c *mockAdditionalMountsInitContainerGenerator_BuildAdditionalMountInitContainer_Call) Run(run func(ctx context.Context, dogu *core.Dogu, doguResource *v2.Dogu, image string, requirements v1.ResourceRequirements)) *mockAdditionalMountsInitContainerGenerator_BuildAdditionalMountInitContainer_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(*core.Dogu), args[1].(*v2.Dogu), args[2].(string), args[3].(v1.ResourceRequirements))
+		run(args[0].(context.Context), args[1].(*core.Dogu), args[2].(*v2.Dogu), args[3].(string), args[4].(v1.ResourceRequirements))
 	})
 	return _c
 }
@@ -80,7 +83,7 @@ func (_c *mockAdditionalMountsInitContainerGenerator_BuildAdditionalMountInitCon
 	return _c
 }
 
-func (_c *mockAdditionalMountsInitContainerGenerator_BuildAdditionalMountInitContainer_Call) RunAndReturn(run func(*core.Dogu, *v2.Dogu, string, v1.ResourceRequirements) (*v1.Container, error)) *mockAdditionalMountsInitContainerGenerator_BuildAdditionalMountInitContainer_Call {
+func (_c *mockAdditionalMountsInitContainerGenerator_BuildAdditionalMountInitContainer_Call) RunAndReturn(run func(context.Context, *core.Dogu, *v2.Dogu, string, v1.ResourceRequirements) (*v1.Container, error)) *mockAdditionalMountsInitContainerGenerator_BuildAdditionalMountInitContainer_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
Without it, the local config gets the owner id from the init container on first start. For most dogus, this is okay because nearly all ids are 1000 and do not conflict with the id from the init container. But e.g. ldap has the id 100.
The additionalMount initContainer has no permissions for the local config in this case.

Resolves #248 