### PR TITLE
#255 added dogu-name as environment-variable for exporter-sidecar-container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- [#255] updated exporter-sidecar to registry.cloudogu.com/k8s/rsync-sidecar:1.1.0
+
+### Added
+- [#255] dogu-name as environment-variable for exporter-sidecar-container
 
 ## [v3.10.0] - 2025-07-02
 ### Added

--- a/controllers/resource/resource_generator.go
+++ b/controllers/resource/resource_generator.go
@@ -383,6 +383,12 @@ func getExporterContainer(dogu *core.Dogu, doguResource *k8sv2.Dogu, exporterIma
 		Name:         CreateExporterContainerName(doguResource.Name),
 		Image:        exporterImage,
 		VolumeMounts: createExporterSidecarVolumeMounts(doguResource, dogu),
+		Env: []corev1.EnvVar{
+			{
+				Name:  "DOGU_NAME",
+				Value: dogu.GetSimpleName(),
+			},
+		},
 		SecurityContext: &corev1.SecurityContext{
 			Capabilities: &corev1.Capabilities{
 				Drop: []corev1.Capability{core.All},

--- a/controllers/resource/testdata/ldap_expectedDeployment_ExporterSidecar.yaml
+++ b/controllers/resource/testdata/ldap_expectedDeployment_ExporterSidecar.yaml
@@ -161,6 +161,9 @@ spec:
             timeoutSeconds: 1
         - image: exporter:0.0.1
           name: ldap-exporter
+          Env:
+            - name: DOGU_NAME
+              value: ldap
           resources: { }
           securityContext:
             appArmorProfile:

--- a/k8s/helm/component-patch-tpl.yaml
+++ b/k8s/helm/component-patch-tpl.yaml
@@ -3,7 +3,7 @@ values:
   images:
     doguOperator: cloudogu/k8s-dogu-operator:3.10.0
     chownInitImage: busybox:1.36
-    exporterImage: registry.cloudogu.com/k8s/rsync-sidecar:1.0.0
+    exporterImage: registry.cloudogu.com/k8s/rsync-sidecar:1.1.0
     additionalMountsInitContainerImage: cloudogu/dogu-additional-mounts-init:0.1.2
 patches:
   values.yaml:

--- a/k8s/helm/values.yaml
+++ b/k8s/helm/values.yaml
@@ -9,7 +9,7 @@ additionalImages:
   # chownInitImage will be used to change file permissions on writeable dogu volumes
   chownInitImage: busybox:1.36
   # exporterImage will be used as sidecar container if the export-mode of a dogu is active
-  exporterImage: registry.cloudogu.com/k8s/rsync-sidecar:1.0.0
+  exporterImage: registry.cloudogu.com/k8s/rsync-sidecar:1.1.0
   # additionalMountsInitContainerImage will be used as init container if the dogu mounts additional data
   additionalMountsInitContainerImage: cloudogu/dogu-additional-mounts-init:0.1.2
 controllerManager:


### PR DESCRIPTION
updated exporter-sidecar to registry.cloudogu.com/k8s/rsync-sidecar:1.1.0


closes #255 