### PR TITLE
#311 fix exposed port annotation mapping to use the dogu host port as `port` and container port as `targetPort`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- [#311] exposed port annotation mapping to use the dogu host port as `port` and container port as `targetPort`
 
 ## [v3.25.0] - 2026-05-19
 ### Fixed

--- a/controllers/annotation/cesExposedPortAnnotator.go
+++ b/controllers/annotation/cesExposedPortAnnotator.go
@@ -18,7 +18,7 @@ type CesExposedPortAnnotator struct{}
 // AnnotateService annotates a given service with exposed ports.
 // Can bes used to identify services with exposed ports and get information about these ports
 // Services are annotated like this:
-// k8s-dogu-operator.cloudogu.com/ces-exposed-ports = [{"protocol":"tcp","port":2222,"targetPort":2222},{"protocol":"udp","port":8080,"targetPort":80}]
+// k8s-dogu-operator.cloudogu.com/ces-exposed-ports = [{"protocol":"tcp","port":2222,"targetPort":2222},{"protocol":"udp","port":80,"targetPort":8080}]
 func (c *CesExposedPortAnnotator) AnnotateService(service *corev1.Service, dogu *core.Dogu) error {
 	exposedPorts := serviceaccess.CollectExposedPorts(dogu)
 

--- a/controllers/annotation/cesExposedPortAnnotator_test.go
+++ b/controllers/annotation/cesExposedPortAnnotator_test.go
@@ -35,7 +35,7 @@ func TestCesExposedPortAnnotator_AnnotateService(t *testing.T) {
 					Container: 8080,
 				},
 			},
-			expectedAnnotation: "[{\"protocol\":\"tcp\",\"port\":2222,\"targetPort\":2222},{\"protocol\":\"udp\",\"port\":8080,\"targetPort\":80}]",
+			expectedAnnotation: "[{\"protocol\":\"tcp\",\"port\":2222,\"targetPort\":2222},{\"protocol\":\"udp\",\"port\":80,\"targetPort\":8080}]",
 		},
 		{
 			name: "Successfully remove unnecessary annotations",
@@ -51,7 +51,7 @@ func TestCesExposedPortAnnotator_AnnotateService(t *testing.T) {
 					Container: 8080,
 				},
 			},
-			expectedAnnotation: "[{\"protocol\":\"tcp\",\"port\":2222,\"targetPort\":2222},{\"protocol\":\"udp\",\"port\":8080,\"targetPort\":80}]",
+			expectedAnnotation: "[{\"protocol\":\"tcp\",\"port\":2222,\"targetPort\":2222},{\"protocol\":\"udp\",\"port\":80,\"targetPort\":8080}]",
 			updatedExposedPorts: []core.ExposedPort{
 				{
 					Type:      "tcp",
@@ -85,7 +85,7 @@ func TestCesExposedPortAnnotator_AnnotateService(t *testing.T) {
 					Container: 443,
 				},
 			},
-			expectedAnnotation:        "[{\"protocol\":\"tcp\",\"port\":2222,\"targetPort\":2222},{\"protocol\":\"udp\",\"port\":8080,\"targetPort\":80},{\"protocol\":\"tcp\",\"port\":22,\"targetPort\":22},{\"protocol\":\"tcp\",\"port\":443,\"targetPort\":443}]",
+			expectedAnnotation:        "[{\"protocol\":\"tcp\",\"port\":2222,\"targetPort\":2222},{\"protocol\":\"udp\",\"port\":80,\"targetPort\":8080},{\"protocol\":\"tcp\",\"port\":22,\"targetPort\":22},{\"protocol\":\"tcp\",\"port\":443,\"targetPort\":443}]",
 			updatedExposedPorts:       []core.ExposedPort{},
 			updatedExpectedAnnotation: "",
 		},
@@ -103,7 +103,7 @@ func TestCesExposedPortAnnotator_AnnotateService(t *testing.T) {
 					Container: 8080,
 				},
 			},
-			expectedAnnotation: "[{\"protocol\":\"tcp\",\"port\":2222,\"targetPort\":2222},{\"protocol\":\"udp\",\"port\":8080,\"targetPort\":80}]",
+			expectedAnnotation: "[{\"protocol\":\"tcp\",\"port\":2222,\"targetPort\":2222},{\"protocol\":\"udp\",\"port\":80,\"targetPort\":8080}]",
 			updatedExposedPorts: []core.ExposedPort{
 				{
 					Type:      "tcp",
@@ -126,7 +126,7 @@ func TestCesExposedPortAnnotator_AnnotateService(t *testing.T) {
 					Container: 443,
 				},
 			},
-			updatedExpectedAnnotation: "[{\"protocol\":\"tcp\",\"port\":2222,\"targetPort\":2222},{\"protocol\":\"udp\",\"port\":8080,\"targetPort\":80},{\"protocol\":\"tcp\",\"port\":22,\"targetPort\":22},{\"protocol\":\"tcp\",\"port\":443,\"targetPort\":443}]",
+			updatedExpectedAnnotation: "[{\"protocol\":\"tcp\",\"port\":2222,\"targetPort\":2222},{\"protocol\":\"udp\",\"port\":80,\"targetPort\":8080},{\"protocol\":\"tcp\",\"port\":22,\"targetPort\":22},{\"protocol\":\"tcp\",\"port\":443,\"targetPort\":443}]",
 		},
 	}
 	for _, tt := range tests {

--- a/controllers/exposition/layer4_mapper.go
+++ b/controllers/exposition/layer4_mapper.go
@@ -24,8 +24,8 @@ func buildTCPEntries(serviceName string, exposedPorts []serviceaccess.ExposedPor
 		entries = append(entries, expv1.TCPEntry{
 			Name:                  buildExposedPortEntryName(exposedPort),
 			Service:               serviceName,
-			Port:                  int32(exposedPort.Port),
-			RequestedExternalPort: new(int32(exposedPort.TargetPort)),
+			Port:                  int32(exposedPort.TargetPort),
+			RequestedExternalPort: new(int32(exposedPort.Port)),
 		})
 	}
 
@@ -43,8 +43,8 @@ func buildUDPEntries(serviceName string, exposedPorts []serviceaccess.ExposedPor
 		entries = append(entries, expv1.UDPEntry{
 			Name:                  buildExposedPortEntryName(exposedPort),
 			Service:               serviceName,
-			Port:                  int32(exposedPort.Port),
-			RequestedExternalPort: new(int32(exposedPort.TargetPort)),
+			Port:                  int32(exposedPort.TargetPort),
+			RequestedExternalPort: new(int32(exposedPort.Port)),
 		})
 	}
 
@@ -52,7 +52,7 @@ func buildUDPEntries(serviceName string, exposedPorts []serviceaccess.ExposedPor
 }
 
 func buildExposedPortEntryName(exposedPort serviceaccess.ExposedPort) string {
-	return fmt.Sprintf("port-%d-%d", exposedPort.Port, exposedPort.TargetPort)
+	return fmt.Sprintf("port-%d-%d", exposedPort.TargetPort, exposedPort.Port)
 }
 
 func normalizedProtocol(exposedPort serviceaccess.ExposedPort) string {

--- a/controllers/exposition/layer4_mapper_test.go
+++ b/controllers/exposition/layer4_mapper_test.go
@@ -12,17 +12,17 @@ func TestBuildTCPEntries(t *testing.T) {
 	exposedPorts := []serviceaccess.ExposedPort{
 		{
 			Protocol:   "tcp",
-			Port:       2222,
-			TargetPort: 32222,
+			Port:       32222,
+			TargetPort: 2222,
 		},
 		{
 			Protocol:   "udp",
-			Port:       5353,
-			TargetPort: 3053,
+			Port:       3053,
+			TargetPort: 5353,
 		},
 		{
-			Port:       8443,
-			TargetPort: 30443,
+			Port:       30443,
+			TargetPort: 8443,
 		},
 	}
 
@@ -48,13 +48,13 @@ func TestBuildUDPEntries(t *testing.T) {
 	exposedPorts := []serviceaccess.ExposedPort{
 		{
 			Protocol:   "tcp",
-			Port:       2222,
-			TargetPort: 32222,
+			Port:       32222,
+			TargetPort: 2222,
 		},
 		{
 			Protocol:   "UDP",
-			Port:       5353,
-			TargetPort: 3053,
+			Port:       3053,
+			TargetPort: 5353,
 		},
 	}
 

--- a/controllers/serviceaccess/exposed_port_collector.go
+++ b/controllers/serviceaccess/exposed_port_collector.go
@@ -16,8 +16,8 @@ func CollectExposedPorts(dogu *core.Dogu) []ExposedPort {
 	for _, exposedPort := range exposedPorts {
 		annotationExposedPorts = append(annotationExposedPorts, ExposedPort{
 			Protocol:   strings.ToLower(exposedPort.GetType()),
-			Port:       exposedPort.Container,
-			TargetPort: exposedPort.Host,
+			Port:       exposedPort.Host,
+			TargetPort: exposedPort.Container,
 		})
 	}
 

--- a/controllers/serviceaccess/exposed_port_collector_test.go
+++ b/controllers/serviceaccess/exposed_port_collector_test.go
@@ -41,18 +41,18 @@ func TestCollectExposedPorts(t *testing.T) {
 		assert.Equal(t, []ExposedPort{
 			{
 				Protocol:   "tcp",
-				Port:       2222,
-				TargetPort: 32222,
+				Port:       32222,
+				TargetPort: 2222,
 			},
 			{
 				Protocol:   "udp",
-				Port:       8080,
-				TargetPort: 30080,
+				Port:       30080,
+				TargetPort: 8080,
 			},
 			{
 				Protocol:   "tcp",
-				Port:       8443,
-				TargetPort: 30443,
+				Port:       30443,
+				TargetPort: 8443,
 			},
 		}, exposedPorts)
 	})


### PR DESCRIPTION
closes #311 